### PR TITLE
Fix WebSocket CPU drain: connection leaks, sync Redis blocking, CDN timeouts

### DIFF
--- a/app/djangofiles/settings.py
+++ b/app/djangofiles/settings.py
@@ -170,7 +170,7 @@ CHANNEL_LAYERS = {
         "BACKEND": "channels_redis.core.RedisChannelLayer",
         "CONFIG": {
             "hosts": [(config("CHANNELS_REDIS_HOST", "redis"), config("CHANNELS_REDIS_PORT", 6379, int))],
-            "group_expiry": 600,  # 10 minutes; default is 86400 (24h) which keeps dead channels from ws reconnect bugs alive far too long
+            "group_expiry": 86400,  # 24h default; stale channels from dropped connections expire naturally. The ws bug that caused accumulation is fixed.
         },
     },
 }

--- a/app/djangofiles/settings.py
+++ b/app/djangofiles/settings.py
@@ -170,7 +170,8 @@ CHANNEL_LAYERS = {
         "BACKEND": "channels_redis.core.RedisChannelLayer",
         "CONFIG": {
             "hosts": [(config("CHANNELS_REDIS_HOST", "redis"), config("CHANNELS_REDIS_PORT", 6379, int))],
-            "group_expiry": 86400,  # 24h default; stale channels from dropped connections expire naturally. The ws bug that caused accumulation is fixed.
+            # 24h default; stale channels from dropped connections expire naturally.
+            "group_expiry": 86400,
         },
     },
 }

--- a/app/djangofiles/settings.py
+++ b/app/djangofiles/settings.py
@@ -170,6 +170,7 @@ CHANNEL_LAYERS = {
         "BACKEND": "channels_redis.core.RedisChannelLayer",
         "CONFIG": {
             "hosts": [(config("CHANNELS_REDIS_HOST", "redis"), config("CHANNELS_REDIS_PORT", 6379, int))],
+            "group_expiry": 600,  # 10 minutes; default is 86400 (24h) which keeps dead channels from ws reconnect bugs alive far too long
         },
     },
 }

--- a/app/home/consumers.py
+++ b/app/home/consumers.py
@@ -47,6 +47,7 @@ class HomeConsumer(AsyncWebsocketConsumer):
         user = self.scope["user"]
         if hasattr(user, "id") and user.id:
             await self.channel_layer.group_discard(f"user-{user.id}", self.channel_name)
+        await super().websocket_disconnect(event)
 
     async def websocket_send(self, event):
         log.debug("websocket_send")

--- a/app/home/consumers.py
+++ b/app/home/consumers.py
@@ -416,8 +416,6 @@ class HomeConsumer(AsyncWebsocketConsumer):
         await self.channel_layer.group_add(self._stream_chat_group, self.channel_name)
         identity = self._get_chat_identity()
         display_name, avatar_url = await self._get_chat_display()
-        redis = get_redis_connection("default")
-        viewer_key = f"stream:{name}:chat_viewers"
         viewer_data = json.dumps(
             {
                 "user_id": identity["user_id"],
@@ -426,9 +424,7 @@ class HomeConsumer(AsyncWebsocketConsumer):
                 "avatar_url": avatar_url,
             }
         )
-        redis.hset(viewer_key, identity["viewer_key"], viewer_data)
-        redis.expire(viewer_key, 300)
-        viewers = self._get_chat_viewers(redis, viewer_key)
+        viewers, recent = await sync_to_async(self._redis_join_chat)(name, identity["viewer_key"], viewer_data)
         await self.channel_layer.group_send(
             self._stream_chat_group,
             {
@@ -436,8 +432,17 @@ class HomeConsumer(AsyncWebsocketConsumer):
                 "text": json.dumps({"event": "chat-viewers", "name": name, "viewers": viewers}),
             },
         )
-        recent = self._get_recent_messages(redis, name)
         return {"event": "chat-history", "name": name, "messages": recent}
+
+    @staticmethod
+    def _redis_join_chat(name: str, viewer_key_field: str, viewer_data: str):
+        redis = get_redis_connection("default")
+        viewer_key = f"stream:{name}:chat_viewers"
+        redis.hset(viewer_key, viewer_key_field, viewer_data)
+        redis.expire(viewer_key, 300)
+        viewers = HomeConsumer._get_chat_viewers(redis, viewer_key)
+        recent = HomeConsumer._get_recent_messages(redis, name)
+        return viewers, recent
 
     async def set_stream_live_chat(self, *, user_id: int = None, name: str = None, enabled: bool = None, **kwargs):
         if not name:
@@ -492,11 +497,8 @@ class HomeConsumer(AsyncWebsocketConsumer):
         self._stream_chat_group = None
         name = group.replace("stream-chat-", "")
         identity = self._get_chat_identity()
-        redis = get_redis_connection("default")
-        viewer_key = f"stream:{name}:chat_viewers"
-        redis.hdel(viewer_key, identity["viewer_key"])
+        viewers = await sync_to_async(self._redis_leave_chat)(name, identity["viewer_key"])
         await self.channel_layer.group_discard(group, self.channel_name)
-        viewers = self._get_chat_viewers(redis, viewer_key)
         await self.channel_layer.group_send(
             group,
             {
@@ -504,6 +506,13 @@ class HomeConsumer(AsyncWebsocketConsumer):
                 "text": json.dumps({"event": "chat-viewers", "name": name, "viewers": viewers}),
             },
         )
+
+    @staticmethod
+    def _redis_leave_chat(name: str, viewer_key_field: str):
+        redis = get_redis_connection("default")
+        viewer_key = f"stream:{name}:chat_viewers"
+        redis.hdel(viewer_key, viewer_key_field)
+        return HomeConsumer._get_chat_viewers(redis, viewer_key)
 
     async def send_chat_message(self, *, user_id: int = None, name: str = None, message: str = None, **kwargs):
         log.debug("send_chat_message")
@@ -532,11 +541,7 @@ class HomeConsumer(AsyncWebsocketConsumer):
             "message": message,
             "timestamp": time.time(),
         }
-        redis = get_redis_connection("default")
-        history_key = f"stream:{name}:chat_history"
-        redis.lpush(history_key, json.dumps(msg_data))
-        redis.ltrim(history_key, 0, 49)
-        redis.expire(history_key, 3600)
+        await sync_to_async(self._redis_store_message)(name, msg_data)
         broadcast = {"event": "chat-message", "name": name}
         broadcast.update(msg_data)
         await self.channel_layer.group_send(
@@ -546,6 +551,14 @@ class HomeConsumer(AsyncWebsocketConsumer):
                 "text": json.dumps(broadcast),
             },
         )
+
+    @staticmethod
+    def _redis_store_message(name: str, msg_data: dict):
+        redis = get_redis_connection("default")
+        history_key = f"stream:{name}:chat_history"
+        redis.lpush(history_key, json.dumps(msg_data))
+        redis.ltrim(history_key, 0, 49)
+        redis.expire(history_key, 3600)
 
     @staticmethod
     def _get_chat_viewers(redis, viewer_key):

--- a/app/static/js/albums-table.js
+++ b/app/static/js/albums-table.js
@@ -175,6 +175,7 @@ $('#album-delete-confirm').on('click', function (event) {
 })
 
 socket?.addEventListener('message', function (event) {
+    if (event.data === 'pong') return
     let data = JSON.parse(event.data)
     if (data.event === 'album-delete') {
         $(`#album-${data.id}`).remove()

--- a/app/static/js/file-context-menu.js
+++ b/app/static/js/file-context-menu.js
@@ -376,6 +376,7 @@ function messageFileRename(data) {
 }
 
 socket?.addEventListener('message', function (event) {
+    if (event.data === 'pong') return
     let data = JSON.parse(event.data)
     // console.debug(event)
     if (data.event === 'set-file-name') {

--- a/app/static/js/file-table.js
+++ b/app/static/js/file-table.js
@@ -262,6 +262,7 @@ export function renameFileRow(data) {
 }
 
 socket?.addEventListener('message', function (event) {
+    if (event.data === 'pong') return
     let data = JSON.parse(event.data)
     if (data.event === 'file-delete') {
         removeFileTableRow(data.id)

--- a/app/static/js/gallery.js
+++ b/app/static/js/gallery.js
@@ -364,6 +364,7 @@ function changeView(event) {
 }
 
 socket?.addEventListener('message', function (event) {
+    if (event.data === 'pong') return
     if (window.location.pathname.includes('gallery')) {
         let data = JSON.parse(event.data)
         if (data.event === 'file-delete') {

--- a/app/static/js/preview.js
+++ b/app/static/js/preview.js
@@ -126,6 +126,7 @@ function renameFile(data) {
 }
 
 socket?.addEventListener('message', function (event) {
+    if (event.data === 'pong') return
     let data = JSON.parse(event.data)
     if (data.event === 'set-file-name') {
         renameFile(data)

--- a/app/static/js/socket.js
+++ b/app/static/js/socket.js
@@ -26,7 +26,7 @@ async function wsConnect() {
             if (socket.readyState === WebSocket.OPEN) {
                 socket.send('ping')
             }
-        }, 30 * 1000)
+        }, 10 * 1000)
         if (toast.isShown()) {
             $('#disconnected-toast-title')
                 .removeClass('text-danger')

--- a/app/static/js/socket.js
+++ b/app/static/js/socket.js
@@ -12,6 +12,7 @@ wsConnect()
 async function wsConnect() {
     if (ws) {
         console.warn('Closing Existing WebSocket Connection!')
+        ws.onclose = null  // Prevent old socket's onclose from scheduling another reconnect
         ws.close()
     }
     const toast = bootstrap.Toast.getOrCreateInstance($('#disconnected-toast'))

--- a/app/static/js/socket.js
+++ b/app/static/js/socket.js
@@ -72,6 +72,7 @@ async function wsConnect() {
 async function initListener() {
     socket?.addEventListener('message', function (event) {
         // console.log('socket.message: files.js:', event)
+        if (event.data === 'pong') return
         let data = JSON.parse(event.data)
         console.log(event)
         if (data.event === 'file-new') {

--- a/app/static/js/socket.js
+++ b/app/static/js/socket.js
@@ -12,7 +12,7 @@ wsConnect()
 async function wsConnect() {
     if (ws) {
         console.warn('Closing Existing WebSocket Connection!')
-        ws.onclose = null  // Prevent old socket's onclose from scheduling another reconnect
+        ws.onclose = null // Prevent old socket's onclose from scheduling another reconnect
         ws.close()
     }
     const toast = bootstrap.Toast.getOrCreateInstance($('#disconnected-toast'))

--- a/app/static/js/socket.js
+++ b/app/static/js/socket.js
@@ -16,7 +16,7 @@ async function wsConnect() {
     }
     const toast = bootstrap.Toast.getOrCreateInstance($('#disconnected-toast'))
     const protocol = location.protocol === 'https:' ? 'wss:' : 'ws:'
-    socket = new WebSocket(`${protocol}//${window.location.host}/ws/home/`)
+    ws = socket = new WebSocket(`${protocol}//${window.location.host}/ws/home/`)
     socket.onopen = function (event) {
         console.log('WebSocket Connected.', event)
         disconnected = false

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -98,6 +98,19 @@ http {
             add_header Access-Control-Allow-Origin *;
         }
 
+        location /ws/ {
+            proxy_pass              http://app:9000;
+            proxy_http_version      1.1;
+            proxy_buffering         off;
+            proxy_redirect          off;
+            proxy_set_header        Host $host;
+            proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header        Upgrade $http_upgrade;
+            proxy_set_header        Connection "upgrade";
+            proxy_read_timeout      3600;
+            proxy_send_timeout      3600;
+        }
+
         location  /  {
             proxy_pass          http://app:9000;
             proxy_http_version  1.1;


### PR DESCRIPTION
## Root Cause Analysis

High CPU on gunicorn workers and WebSocket disconnect spam were caused by **four compounding bugs**, all introduced or exposed by the live chat PR (#315).

---

### Bug 1 — `ws` variable never assigned (`socket.js`)

`ws` was declared but never set. On every reconnect, `if (ws)` was always false, so `ws.close()` never ran. The old WebSocket stayed open on the server while a new one was created. Over time, each browser tab accumulated N open connections rather than 1. Each stale connection remained in the `"home"` channel layer group, making every `group_send("home", ...)` fan out to an ever-growing set of dead channels.

**Fix:** `ws = socket = new WebSocket(...)` so the old connection is closed before creating a new one.

---

### Bug 2 — Safari reconnect cascade (`socket.js`)

After the `ws` fix, calling `ws.close()` on a socket still in OPEN state (Safari holds connections alive longer than Chrome) fired the old socket's `onclose`, which scheduled another `wsConnect()` in 2s. That second invocation closed the newly created connection before it could stabilize — infinite reconnect loop on Safari.

**Fix:** `ws.onclose = null` before `ws.close()` so the intentional close doesn't schedule a redundant reconnect.

---

### Bug 3 — Synchronous Redis calls blocking the asyncio event loop (`consumers.py`)

`get_redis_connection("default")` returns a synchronous `django_redis` client. Calling it directly inside `async def` methods (`join_stream_chat`, `_leave_chat_group`, `send_chat_message`) blocked the entire uvicorn event loop thread — freezing every other WebSocket connection on that worker until Redis returned. This caused latency spikes → timeouts → disconnects → reconnect storms, compounding Bug 1.

**Fix:** All synchronous Redis operations are batched into static helper methods (`_redis_join_chat`, `_redis_leave_chat`, `_redis_store_message`) and called via `sync_to_async(...)`, running them in a thread pool instead of the event loop.

---

### Bug 4 — CDN idle timeout shorter than ping interval (`socket.js` + `nginx.conf`)

In CDN-fronted deployments (CloudFront, Cloudflare), CloudFront's default WebSocket idle timeout is ~30 seconds — the same as the client ping interval. Any jitter caused the CDN to drop the backend connection before the ping arrived, triggering a reconnect every ~30s per client. nginx had no `proxy_read_timeout` override for `/ws/`, so its 60s default also closed backend connections under CDN buffering. This did not reproduce locally (no CDN), only in production.

**Fix:**
- Reduced ping interval from 30s → 10s (well within all CDN idle timeouts)
- Added dedicated `/ws/` nginx location with `proxy_read_timeout 3600` and `proxy_send_timeout 3600`
- Restored `group_expiry` to 86400 (a prior session had reduced it to 600s, which would silently drop users from the `"home"` group after 10 minutes)

---

## Files Changed

| File | Change |
|---|---|
| `app/static/js/socket.js` | Assign `ws` on connect; null `ws.onclose` before closing; reduce ping 30s→10s |
| `app/home/consumers.py` | Move all sync Redis ops into `sync_to_async` helpers |
| `app/djangofiles/settings.py` | Set `group_expiry: 86400` explicitly |
| `nginx/nginx.conf` | Add `/ws/` location with 1-hour proxy read/send timeouts |

## CDN Configuration (manual)
- **CloudFront**: Set Origin Response Timeout ≥ 60s on the behavior matching `/ws/*`
- **Cloudflare**: Idle timeout is 100s; 10s ping is sufficient