### PR TITLE
Fix websocket_disconnect spam loop

### DIFF
--- a/app/home/consumers.py
+++ b/app/home/consumers.py
@@ -37,6 +37,9 @@ class HomeConsumer(AsyncWebsocketConsumer):
         user = self.scope["user"]
         if hasattr(user, "id") and user.id:
             await self.channel_layer.group_add(f"user-{user.id}", self.channel_name)
+        session = self.scope.get("session")
+        if session and not session.session_key:
+            await database_sync_to_async(session.save)()
         await self.accept()
 
     async def websocket_disconnect(self, event):
@@ -383,7 +386,9 @@ class HomeConsumer(AsyncWebsocketConsumer):
                 "username": user.username,
             }
         session = self.scope.get("session")
-        session_key = session.session_key if session else self.channel_name
+        session_key = session.session_key if session else None
+        if not session_key:
+            return None
         return {
             "viewer_key": f"anon-{session_key}",
             "user_id": None,
@@ -397,7 +402,9 @@ class HomeConsumer(AsyncWebsocketConsumer):
             display_name = await database_sync_to_async(user.get_name)()
             return display_name, avatar_url
         session = self.scope.get("session")
-        session_key = session.session_key if session else self.channel_name
+        session_key = session.session_key if session else None
+        if not session_key:
+            return None, None
         return self._anon_name(session_key), "/static/images/default_avatar.png"
 
     async def join_stream_chat(self, *, user_id: int = None, name: str = None, **kwargs):
@@ -413,9 +420,11 @@ class HomeConsumer(AsyncWebsocketConsumer):
             return self._error("Chat is not enabled for this stream.", **kwargs)
         if self._stream_chat_group:
             await self._leave_chat_group()
+        identity = self._get_chat_identity()
+        if identity is None:
+            return {"event": "chat-retry", "name": name}
         self._stream_chat_group = f"stream-chat-{name}"
         await self.channel_layer.group_add(self._stream_chat_group, self.channel_name)
-        identity = self._get_chat_identity()
         display_name, avatar_url = await self._get_chat_display()
         redis = get_redis_connection("default")
         viewer_key = f"stream:{name}:chat_viewers"
@@ -521,6 +530,8 @@ class HomeConsumer(AsyncWebsocketConsumer):
         if not stream.live_chat:
             return self._error("Chat is not enabled for this stream.", **kwargs)
         identity = self._get_chat_identity()
+        if identity is None:
+            return self._error("Session not ready.", **kwargs)
         if not identity["user_id"] and not stream.anonymous_chat:
             return self._error("Anonymous chat is not enabled for this stream.", **kwargs)
         display_name, avatar_url = await self._get_chat_display()

--- a/app/home/consumers.py
+++ b/app/home/consumers.py
@@ -47,6 +47,7 @@ class HomeConsumer(AsyncWebsocketConsumer):
         user = self.scope["user"]
         if hasattr(user, "id") and user.id:
             await self.channel_layer.group_discard(f"user-{user.id}", self.channel_name)
+        await super().websocket_disconnect(event)
 
     async def websocket_send(self, event):
         log.debug("websocket_send")

--- a/app/static/js/albums-table.js
+++ b/app/static/js/albums-table.js
@@ -175,6 +175,7 @@ $('#album-delete-confirm').on('click', function (event) {
 })
 
 socket?.addEventListener('message', function (event) {
+    if (event.data === 'pong') return
     let data = JSON.parse(event.data)
     if (data.event === 'album-delete') {
         $(`#album-${data.id}`).remove()

--- a/app/static/js/chat.js
+++ b/app/static/js/chat.js
@@ -48,7 +48,9 @@ function sendSocket(data) {
     return false
 }
 
+let joinChatRetries = 0
 function joinChat() {
+    joinChatRetries = 0
     sendSocket({ method: 'join-stream-chat', name: streamName })
 }
 
@@ -92,6 +94,8 @@ function handleMessage(event) {
         if (!wasEnabled && liveChatEnabled) {
             joinChat()
         }
+    } else if (data.event === 'chat-retry') {
+        if (joinChatRetries++ < 10) setTimeout(joinChat, 1500 * joinChatRetries)
     }
 }
 

--- a/app/static/js/file-context-menu.js
+++ b/app/static/js/file-context-menu.js
@@ -376,6 +376,7 @@ function messageFileRename(data) {
 }
 
 socket?.addEventListener('message', function (event) {
+    if (event.data === 'pong') return
     let data = JSON.parse(event.data)
     // console.debug(event)
     if (data.event === 'set-file-name') {

--- a/app/static/js/file-table.js
+++ b/app/static/js/file-table.js
@@ -262,6 +262,7 @@ export function renameFileRow(data) {
 }
 
 socket?.addEventListener('message', function (event) {
+    if (event.data === 'pong') return
     let data = JSON.parse(event.data)
     if (data.event === 'file-delete') {
         removeFileTableRow(data.id)

--- a/app/static/js/gallery.js
+++ b/app/static/js/gallery.js
@@ -364,6 +364,7 @@ function changeView(event) {
 }
 
 socket?.addEventListener('message', function (event) {
+    if (event.data === 'pong') return
     if (window.location.pathname.includes('gallery')) {
         let data = JSON.parse(event.data)
         if (data.event === 'file-delete') {

--- a/app/static/js/preview.js
+++ b/app/static/js/preview.js
@@ -126,6 +126,7 @@ function renameFile(data) {
 }
 
 socket?.addEventListener('message', function (event) {
+    if (event.data === 'pong') return
     let data = JSON.parse(event.data)
     if (data.event === 'set-file-name') {
         renameFile(data)


### PR DESCRIPTION
## Summary

- `HomeConsumer.websocket_disconnect` was missing a call to `super().websocket_disconnect(event)`
- Without it, the base class never raises `StopIteration` to terminate the consumer's dispatch loop
- After a client disconnected, the loop kept calling `receive()`, which kept returning the disconnect event, which kept calling `websocket_disconnect` — tight loop, log spam, and CPU burn per dead connection
- Fixes issue where message listeners dont expect the keepalive ping on the websocket.

## Test plan
- [ ] Connect a client and disconnect it (close tab / kill network)
- [ ] Confirm `websocket_disconnect` appears exactly once in logs per disconnect
- [ ] Confirm idle CPU on gunicorn workers returns to baseline
