### PR TITLE
Live chat security, bug, and efficiency fixes

### DIFF
--- a/app/home/consumers.py
+++ b/app/home/consumers.py
@@ -414,10 +414,8 @@ class HomeConsumer(AsyncWebsocketConsumer):
             return self._error(_ERR_NO_STREAM_NAME, **kwargs)
         stream = await database_sync_to_async(Stream.objects.filter)(name=name)
         stream = await database_sync_to_async(lambda qs: qs[0] if qs else None)(stream)
-        if not stream:
-            return self._error(_ERR_STREAM_NOT_FOUND, **kwargs)
-        if not stream.live_chat:
-            return self._error("Chat is not enabled for this stream.", **kwargs)
+        if not stream or not stream.live_chat:
+            return self._error("Chat is not available.", **kwargs)
         if self._stream_chat_group:
             await self._leave_chat_group()
         identity = self._get_chat_identity()
@@ -428,26 +426,27 @@ class HomeConsumer(AsyncWebsocketConsumer):
         display_name, avatar_url = await self._get_chat_display()
         redis = get_redis_connection("default")
         viewer_key = f"stream:{name}:chat_viewers"
-        viewer_data = json.dumps(
-            {
-                "user_id": identity["user_id"],
-                "username": identity["username"],
-                "display_name": display_name,
-                "avatar_url": avatar_url,
-            }
-        )
-        redis.hset(viewer_key, identity["viewer_key"], viewer_data)
+        viewer_data_dict = {
+            "viewer_id": identity["viewer_key"],
+            "user_id": identity["user_id"],
+            "username": identity["username"],
+            "display_name": display_name,
+            "avatar_url": avatar_url,
+        }
+        redis.hset(viewer_key, identity["viewer_key"], json.dumps(viewer_data_dict))
         redis.expire(viewer_key, 300)
-        viewers = self._get_chat_viewers(redis, viewer_key)
+        # Broadcast delta: new viewer joined
         await self.channel_layer.group_send(
             self._stream_chat_group,
             {
                 "type": _WS_SEND,
-                "text": json.dumps({"event": "chat-viewers", "name": name, "viewers": viewers}),
+                "text": json.dumps({"event": "chat-viewer-joined", "name": name, "viewer": viewer_data_dict}),
             },
         )
+        # Send full viewer list + history only to the joining user
+        viewers = self._get_chat_viewers(redis, viewer_key)
         recent = self._get_recent_messages(redis, name)
-        return {"event": "chat-history", "name": name, "messages": recent}
+        return {"event": "chat-history", "name": name, "messages": recent, "viewers": viewers}
 
     async def set_stream_live_chat(self, *, user_id: int = None, name: str = None, enabled: bool = None, **kwargs):
         if not name:
@@ -457,7 +456,7 @@ class HomeConsumer(AsyncWebsocketConsumer):
         if not stream:
             return self._error(_ERR_STREAM_NOT_FOUND, **kwargs)
         stream_user_id = await database_sync_to_async(lambda s: s.user.id)(stream)
-        if user_id and stream_user_id != user_id:
+        if not user_id or stream_user_id != user_id:
             return self._error(_ERR_STREAM_OWNED_BY_OTHER, **kwargs)
         stream.live_chat = bool(enabled)
         await database_sync_to_async(stream.save)()
@@ -480,7 +479,7 @@ class HomeConsumer(AsyncWebsocketConsumer):
         if not stream:
             return self._error(_ERR_STREAM_NOT_FOUND, **kwargs)
         stream_user_id = await database_sync_to_async(lambda s: s.user.id)(stream)
-        if user_id and stream_user_id != user_id:
+        if not user_id or stream_user_id != user_id:
             return self._error(_ERR_STREAM_OWNED_BY_OTHER, **kwargs)
         stream.anonymous_chat = bool(enabled)
         await database_sync_to_async(stream.save)()
@@ -506,12 +505,11 @@ class HomeConsumer(AsyncWebsocketConsumer):
         viewer_key = f"stream:{name}:chat_viewers"
         redis.hdel(viewer_key, identity["viewer_key"])
         await self.channel_layer.group_discard(group, self.channel_name)
-        viewers = self._get_chat_viewers(redis, viewer_key)
         await self.channel_layer.group_send(
             group,
             {
                 "type": _WS_SEND,
-                "text": json.dumps({"event": "chat-viewers", "name": name, "viewers": viewers}),
+                "text": json.dumps({"event": "chat-viewer-left", "name": name, "viewer_id": identity["viewer_key"]}),
             },
         )
 
@@ -523,6 +521,17 @@ class HomeConsumer(AsyncWebsocketConsumer):
         if not message or not message.strip():
             return self._error("Empty message.", **kwargs)
         message = message.strip()[:500]
+        # Rate limit: max 3 messages per second per user
+        _identity_for_rate = self._get_chat_identity()
+        if _identity_for_rate:
+            rate_key = f"stream:{name}:rate:{_identity_for_rate['viewer_key']}"
+            redis_rate = get_redis_connection("default")
+            pipe = redis_rate.pipeline()
+            pipe.incr(rate_key)
+            pipe.expire(rate_key, 1)
+            count, _ = pipe.execute()
+            if count > 3:
+                return self._error("Slow down. Too many messages.", **kwargs)
         stream = await database_sync_to_async(Stream.objects.filter)(name=name)
         stream = await database_sync_to_async(lambda qs: qs[0] if qs else None)(stream)
         if not stream:
@@ -546,9 +555,11 @@ class HomeConsumer(AsyncWebsocketConsumer):
         }
         redis = get_redis_connection("default")
         history_key = f"stream:{name}:chat_history"
-        redis.lpush(history_key, json.dumps(msg_data))
-        redis.ltrim(history_key, 0, 49)
-        redis.expire(history_key, 3600)
+        pipe = redis.pipeline()
+        pipe.lpush(history_key, json.dumps(msg_data))
+        pipe.ltrim(history_key, 0, 49)
+        pipe.expire(history_key, 3600)
+        pipe.execute()
         broadcast = {"event": "chat-message", "name": name}
         broadcast.update(msg_data)
         await self.channel_layer.group_send(

--- a/app/static/js/chat.js
+++ b/app/static/js/chat.js
@@ -73,7 +73,12 @@ const viewerMap = new Map()
 
 function updateViewers(viewers) {
     viewerMap.clear()
-    viewers.forEach((v) => viewerMap.set(v.viewer_id ?? (v.user_id != null ? String(v.user_id) : v.username), v))
+    viewers.forEach((v) =>
+        viewerMap.set(
+            v.viewer_id ?? (v.user_id != null ? String(v.user_id) : v.username),
+            v
+        )
+    )
     renderViewers()
 }
 
@@ -127,7 +132,8 @@ function handleMessage(event) {
         updateViewers(data.viewers)
     } else if (data.event === 'chat-viewer-joined') {
         const v = data.viewer
-        const key = v.viewer_id ?? (v.user_id != null ? String(v.user_id) : v.username)
+        const key =
+            v.viewer_id ?? (v.user_id != null ? String(v.user_id) : v.username)
         viewerMap.set(key, v)
         renderViewers()
     } else if (data.event === 'chat-viewer-left') {
@@ -285,4 +291,3 @@ function appendMessage(msg) {
         chatMessages.scrollTop = chatMessages.scrollHeight
     }
 }
-

--- a/app/static/js/chat.js
+++ b/app/static/js/chat.js
@@ -65,7 +65,42 @@ function initChat() {
 }
 
 function addSocketListener() {
+    socket?.removeEventListener('message', handleMessage)
     socket?.addEventListener('message', handleMessage)
+}
+
+const viewerMap = new Map()
+
+function updateViewers(viewers) {
+    viewerMap.clear()
+    viewers.forEach((v) => viewerMap.set(v.viewer_id ?? (v.user_id != null ? String(v.user_id) : v.username), v))
+    renderViewers()
+}
+
+function renderViewers() {
+    chatViewerCount.textContent = viewerMap.size
+    const fragment = document.createDocumentFragment()
+    viewerMap.forEach((v) => {
+        const el = document.createElement('div')
+        el.className = 'd-flex align-items-center gap-1 mb-1'
+
+        const avatar = document.createElement('img')
+        avatar.src = v.avatar_url
+        avatar.className = 'rounded-circle'
+        avatar.width = 18
+        avatar.height = 18
+        avatar.alt = v.username
+
+        const name = document.createElement('small')
+        name.className = 'fw-semibold'
+        name.textContent = v.display_name
+
+        el.appendChild(avatar)
+        el.appendChild(name)
+        fragment.appendChild(el)
+    })
+    chatViewersPanel.innerHTML = ''
+    chatViewersPanel.appendChild(fragment)
 }
 
 function handleMessage(event) {
@@ -85,8 +120,19 @@ function handleMessage(event) {
             data.messages.forEach((msg) => appendMessage(msg))
             chatMessages.scrollTop = chatMessages.scrollHeight
         }
+        if (data.viewers) {
+            updateViewers(data.viewers)
+        }
     } else if (data.event === 'chat-viewers') {
         updateViewers(data.viewers)
+    } else if (data.event === 'chat-viewer-joined') {
+        const v = data.viewer
+        const key = v.viewer_id ?? (v.user_id != null ? String(v.user_id) : v.username)
+        viewerMap.set(key, v)
+        renderViewers()
+    } else if (data.event === 'chat-viewer-left') {
+        viewerMap.delete(data.viewer_id)
+        renderViewers()
     } else if (data.event === 'chat-settings') {
         const wasEnabled = liveChatEnabled
         liveChatEnabled = data.live_chat
@@ -133,6 +179,10 @@ function applyChatSettings(data) {
 }
 
 initChat()
+document.addEventListener('wsConnected', () => {
+    addSocketListener()
+    if (liveChatEnabled) joinChat()
+})
 
 // Chat form submit
 if (chatForm && chatInput) {
@@ -236,26 +286,3 @@ function appendMessage(msg) {
     }
 }
 
-function updateViewers(viewers) {
-    chatViewerCount.textContent = viewers.length
-    chatViewersPanel.innerHTML = ''
-    viewers.forEach((v) => {
-        const el = document.createElement('div')
-        el.className = 'd-flex align-items-center gap-1 mb-1'
-
-        const avatar = document.createElement('img')
-        avatar.src = v.avatar_url
-        avatar.className = 'rounded-circle'
-        avatar.width = 18
-        avatar.height = 18
-        avatar.alt = v.username
-
-        const name = document.createElement('small')
-        name.className = 'fw-semibold'
-        name.textContent = v.display_name
-
-        el.appendChild(avatar)
-        el.appendChild(name)
-        chatViewersPanel.appendChild(el)
-    })
-}

--- a/app/static/js/socket.js
+++ b/app/static/js/socket.js
@@ -75,6 +75,7 @@ async function initListener() {
     _initializedSockets.add(socket)
     socket?.addEventListener('message', function (event) {
         // console.log('socket.message: files.js:', event)
+        if (event.data === 'pong') return
         let data = JSON.parse(event.data)
         console.log(event)
         if (data.event === 'file-new') {

--- a/app/static/js/socket.js
+++ b/app/static/js/socket.js
@@ -5,6 +5,7 @@ let disconnected = false
 export let socket //NOSONAR
 let ws
 let heartbeatInterval
+const _initializedSockets = new WeakSet()
 
 console.log('Connecting to WebSocket...')
 wsConnect()
@@ -33,6 +34,7 @@ async function wsConnect() {
                 .text('Connected')
             toast.hide()
         }
+        document.dispatchEvent(new CustomEvent('wsConnected'))
     }
     // socket.onmessage = function (event) {
     //     console.log('socket.onmessage:', event)
@@ -69,6 +71,8 @@ async function wsConnect() {
 // File Events
 
 async function initListener() {
+    if (_initializedSockets.has(socket)) return
+    _initializedSockets.add(socket)
     socket?.addEventListener('message', function (event) {
         // console.log('socket.message: files.js:', event)
         let data = JSON.parse(event.data)


### PR DESCRIPTION
## Summary

- **Auth bypass fix**: `set_stream_live_chat` and `set_stream_anonymous_chat` ownership guards used `if user_id and ...`, allowing requests with a null/missing `user_id` to skip the check entirely. Changed to `if not user_id or ...`.
- **Rate limiting**: `send_chat_message` now enforces a max of 3 messages/second per user via a Redis pipeline counter with a 1s TTL.
- **Atomic Redis writes**: `lpush`/`ltrim`/`expire` in `send_chat_message` are now executed as a single pipeline instead of three separate calls.
- **Stream enumeration prevention**: `join_stream_chat` previously returned distinct errors for "stream not found" vs "chat disabled", leaking stream existence. Both cases now return a generic `"Chat is not available."`.
- **Delta viewer broadcasts**: Instead of broadcasting the full viewer list to all connected users on every join/leave, the backend now sends `chat-viewer-joined` / `chat-viewer-left` delta events. The full list is sent only to the joining user in the `chat-history` response.
- **WebSocket reconnect handling**: `socket.js` dispatches a `wsConnected` DOM event on open. `chat.js` listens for this to re-register its message handler and rejoin chat after reconnects — previously chat silently broke after any disconnect.
- **Duplicate listener guard**: `socket.js` uses a `WeakSet` to prevent `initListener` from registering duplicate handlers on the same socket instance. `chat.js` calls `removeEventListener` before `addEventListener` in `addSocketListener`.
- **DOM performance**: `updateViewers` now uses a `Map` for O(1) delta updates and a `DocumentFragment` for a single DOM insertion instead of per-viewer appends.