### PR TITLE
UI enhancements: DataTables toolbar, reduced padding, album create modal

### DIFF
--- a/app/home/tests.py
+++ b/app/home/tests.py
@@ -229,6 +229,8 @@ class PlaywrightTest(ChannelsLiveServerTestCase):
 
             if view == "Albums":
                 print("=========== ALBUMS ===============")
+                page.get_by_role("button", name="New Album").click()
+                page.locator("#create-album-modal").wait_for(state="visible")
                 page.locator("#name").fill("My Cool Pictures")
                 page.get_by_role("button", name="Create").click()
                 flush_template_cache()

--- a/app/static/css/gallery.css
+++ b/app/static/css/gallery.css
@@ -121,7 +121,7 @@ div.dataTables_wrapper span.select-item {
     top: -2px;
 }
 
-#files-table_wrapper .dt-layout-end {
+[id='files-table_wrapper'] .dt-layout-end {
     display: flex;
     align-items: center;
     gap: 0.5rem;

--- a/app/static/css/gallery.css
+++ b/app/static/css/gallery.css
@@ -18,7 +18,7 @@
 }
 
 .dt-processing {
-    position: relative !important;
+    position: absolute !important;
     top: 100% !important;
 }
 
@@ -110,4 +110,24 @@ highlight a row and it fucks up our other stylings */
 div.dataTables_wrapper span.select-info,
 div.dataTables_wrapper span.select-item {
     margin-left: 0.25em;
+}
+
+#files-table thead th:first-child {
+    vertical-align: middle;
+}
+
+#files-table thead th:first-child input[type="checkbox"] {
+    position: relative;
+    top: -2px;
+}
+
+#files-table_wrapper .dt-layout-end {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    flex-wrap: nowrap;
+}
+
+#dt-user-select-wrapper select {
+    width: auto;
 }

--- a/app/static/css/gallery.css
+++ b/app/static/css/gallery.css
@@ -112,6 +112,13 @@ div.dataTables_wrapper span.select-item {
     margin-left: 0.25em;
 }
 
+#files-table td {
+    max-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
 #files-table thead th:first-child {
     vertical-align: middle;
 }

--- a/app/static/css/gallery.css
+++ b/app/static/css/gallery.css
@@ -119,6 +119,19 @@ div.dataTables_wrapper span.select-item {
     white-space: nowrap;
 }
 
+#files-table .dj-file-link {
+    display: flex;
+    align-items: center;
+    min-width: 0;
+}
+
+#files-table .dj-file-link-ref {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    min-width: 0;
+}
+
 #files-table thead th:first-child {
     vertical-align: middle;
 }

--- a/app/static/css/gallery.css
+++ b/app/static/css/gallery.css
@@ -132,13 +132,25 @@ div.dataTables_wrapper span.select-item {
     min-width: 0;
 }
 
-#files-table thead th:first-child {
-    vertical-align: middle;
+#files-table thead th div.dt-column-header {
+    flex-direction: row;
 }
 
-#files-table thead th:first-child input[type='checkbox'] {
-    position: relative;
-    top: -2px;
+#files-table thead th:first-child div.dt-column-header {
+    align-items: center;
+}
+
+#files-table thead th:first-child div.dt-column-header span.dt-column-order {
+    top: 3px;
+}
+
+#files-table thead th:first-child div.dt-column-header input {
+    order: -1;
+    margin-right: 3px;
+}
+
+#files-table thead th:first-child {
+    vertical-align: middle;
 }
 
 [id='files-table_wrapper'] .dt-layout-end {

--- a/app/static/css/gallery.css
+++ b/app/static/css/gallery.css
@@ -116,7 +116,7 @@ div.dataTables_wrapper span.select-item {
     vertical-align: middle;
 }
 
-#files-table thead th:first-child input[type="checkbox"] {
+#files-table thead th:first-child input[type='checkbox'] {
     position: relative;
     top: -2px;
 }

--- a/app/static/css/main.css
+++ b/app/static/css/main.css
@@ -122,7 +122,7 @@
 
 @supports (padding-top: env(safe-area-inset-top)) {
     body {
-        padding-top: calc(61px + max(env(safe-area-inset-top), 8px));
+        padding-top: calc(61px + env(safe-area-inset-top));
     }
 
     .navbar {

--- a/app/static/js/albums-table.js
+++ b/app/static/js/albums-table.js
@@ -45,7 +45,9 @@ const dataTablesOptions = {
             .find('.dt-layout-start')
             .first()
         startCell.append(
-            $('<button class="btn btn-secondary btn-sm" data-bs-toggle="modal" data-bs-target="#create-album-modal"><i class="fa-solid fa-images me-2"></i> New Album</button>')
+            $(
+                '<button class="btn btn-secondary btn-sm" data-bs-toggle="modal" data-bs-target="#create-album-modal"><i class="fa-solid fa-images me-2"></i> New Album</button>'
+            )
         )
     },
     columnDefs: [

--- a/app/static/js/albums-table.js
+++ b/app/static/js/albums-table.js
@@ -40,6 +40,14 @@ const dataTablesOptions = {
         { data: 'maxv' },
         { data: 'delete' },
     ],
+    initComplete: function () {
+        const startCell = $(this.api().table().container())
+            .find('.dt-layout-start')
+            .first()
+        startCell.append(
+            $('<button class="btn btn-secondary btn-sm" data-bs-toggle="modal" data-bs-target="#create-album-modal"><i class="fa-solid fa-images me-2"></i> New Album</button>')
+        )
+    },
     columnDefs: [
         { targets: 0, width: '30px', responsivePriority: 5 },
         {
@@ -151,9 +159,8 @@ $('#albumsForm').on('submit', function (event) {
         data: JSON.stringify(data),
         headers: { 'X-CSRFToken': csrftoken },
         success: function (data) {
-            // console.log('data:', data)
             form.trigger('reset')
-            // show_toast(`Album Created: ${data.url}`)
+            $('#create-album-modal').modal('hide')
         },
         error: messageErrorHandler,
         cache: false,

--- a/app/static/js/file-table.js
+++ b/app/static/js/file-table.js
@@ -91,14 +91,16 @@ const dataTablesOptions = {
             targets: 4,
             defaultContent: '',
             responsivePriority: 9,
+            className: 'text-nowrap',
         },
         {
             name: 'date',
             targets: 5,
             render: DataTable.render.datetime('DD MMM YYYY, kk:mm'),
             defaultContent: '',
-            responsivePriority: 8,
-            width: '500px',
+            responsivePriority: 9,
+            width: '165px',
+            className: 'text-nowrap',
         },
         {
             targets: 6,

--- a/app/static/js/file-table.js
+++ b/app/static/js/file-table.js
@@ -144,6 +144,25 @@ const dataTablesOptions = {
     language: {
         info: '',
     },
+    initComplete: function () {
+        const container = $(this.api().table().container())
+        const startCell = container.find('.dt-layout-start').first()
+        const endCell = container.find('.dt-layout-end').first()
+
+        const bulkWrapper = document.getElementById('dt-bulk-wrapper')
+        if (bulkWrapper) {
+            startCell.append(bulkWrapper)
+            bulkWrapper.classList.remove('d-none')
+        }
+
+        const userSelectWrapper = document.getElementById(
+            'dt-user-select-wrapper'
+        )
+        if (userSelectWrapper) {
+            endCell.prepend(userSelectWrapper)
+            userSelectWrapper.classList.remove('d-none')
+        }
+    },
 }
 
 export function initFilesTable(search = true, ordering = true, info = true) {

--- a/app/templates/albums.html
+++ b/app/templates/albums.html
@@ -12,54 +12,62 @@
 {% endblock %}
 
 {% block body %}
-<div class="container-fluid py-3 px-4">
+<div class="container-fluid pb-3 pt-2 px-4">
 
-    <h1><i class="fa-solid fa-images me-2"></i> Albums</h1>
-
-    <form id="albumsForm" class="pt-2 pb-2" method="post" action="{% url 'api:album' %}">
-        <div class="row g-1">
-            <div class="col-sm-12">
-                <input type="text" class="form-control" placeholder="Album Name" aria-label="Vanity"
-                       id="name" name="name" required>
-            </div>
-        </div>
-        <div class="row g-1 my-1">
-            <div class="col-12">
-                <input type="text" class="form-control" placeholder="Album Description" aria-label="Album Description"
-                       id="description" name="description">
-            </div>
-        </div>
-        <div class="row my-1 g-1">
-            <div class="col-md-3 d-grid">
-                <button class="btn btn-outline-success" type="submit"><i class="fa-solid fa-images me-2"></i> Create</button>
-            </div>
-            <div class="col-md-3">
-                <div class="input-group w-100">
-                    <input type="password" class="form-control" placeholder="Password" aria-label="Password" id="password" name="password" autocomplete="new-password" >
-                    <button type="button" title="Umask password." id="password-unmask" class="btn btn-secondary btn-sm"><i class="fa-solid fa-eye me-1"></i></button>
-                    <button type="button" title="Copy Password" id="password-copy" class="btn btn-warning btn-sm"><i class="fa-regular fa-copy"></i></button>
-                    <button type="button" title="Generate new password." id="password-generate" class="btn btn-info btn-sm"><i class="fa-solid fa-key"></i></button>
-                </div>
-            </div>
-            <div class="col-md-2">
-                <input type="text" class="form-control" placeholder="Max Views" aria-label="Max-Views"
-                       id="max-views" name="max-views">
-            </div>
-            <div class="col-md-2">
-                <input type="text" class="form-control" placeholder="Expire" aria-label="Expire"
-                       id="expire" name="expire">
-            </div>
-            <div class="col-md-2 d-flex align-items-center">
-                <div class="form-check form-switch ms-2 mt-2 mt-md-0">
-                    <input class="form-check-input" type="checkbox" role="switch" id="private" name="private">
-                    <label class="form-check-label" for="private">Private</label>
-                </div>
-            </div>
-        </div>
-    </form>
     {% include 'include/albums-table.html' %}
 
 </div> <!-- container-fluid -->
+
+<div class="modal fade" id="create-album-modal" tabindex="-1" aria-labelledby="create-album-label" aria-hidden="true">
+    <div class="modal-dialog modal-dialog-centered modal-lg">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="create-album-label"><i class="fa-solid fa-images me-2"></i> New Album</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <form id="albumsForm" method="post" action="{% url 'api:album' %}">
+                <div class="modal-body">
+                    <div class="row g-2">
+                        <div class="col-12">
+                            <input type="text" class="form-control" placeholder="Album Name" aria-label="Album Name"
+                                   id="name" name="name" required>
+                        </div>
+                        <div class="col-12">
+                            <input type="text" class="form-control" placeholder="Album Description" aria-label="Album Description"
+                                   id="description" name="description">
+                        </div>
+                        <div class="col-md-6">
+                            <div class="input-group w-100">
+                                <input type="password" class="form-control" placeholder="Password" aria-label="Password" id="password" name="password" autocomplete="new-password">
+                                <button type="button" title="Unmask password" id="password-unmask" class="btn btn-secondary btn-sm"><i class="fa-solid fa-eye"></i></button>
+                                <button type="button" title="Copy Password" id="password-copy" class="btn btn-warning btn-sm"><i class="fa-regular fa-copy"></i></button>
+                                <button type="button" title="Generate password" id="password-generate" class="btn btn-info btn-sm"><i class="fa-solid fa-key"></i></button>
+                            </div>
+                        </div>
+                        <div class="col-md-3">
+                            <input type="text" class="form-control" placeholder="Max Views" aria-label="Max Views"
+                                   id="max-views" name="max-views">
+                        </div>
+                        <div class="col-md-3">
+                            <input type="text" class="form-control" placeholder="Expire" aria-label="Expire"
+                                   id="expire" name="expire">
+                        </div>
+                        <div class="col-12">
+                            <div class="form-check form-switch ms-1">
+                                <input class="form-check-input" type="checkbox" role="switch" id="private" name="private">
+                                <label class="form-check-label" for="private">Private</label>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <div class="modal-footer">
+                    <button class="btn btn-success" type="submit"><i class="fa-solid fa-images me-2"></i> Create</button>
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>
 {% endblock %}
 
 {% block tail %}

--- a/app/templates/albums.html
+++ b/app/templates/albums.html
@@ -18,56 +18,7 @@
 
 </div> <!-- container-fluid -->
 
-<div class="modal fade" id="create-album-modal" tabindex="-1" aria-labelledby="create-album-label" aria-hidden="true">
-    <div class="modal-dialog modal-dialog-centered modal-lg">
-        <div class="modal-content">
-            <div class="modal-header">
-                <h5 class="modal-title" id="create-album-label"><i class="fa-solid fa-images me-2"></i> New Album</h5>
-                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
-            </div>
-            <form id="albumsForm" method="post" action="{% url 'api:album' %}">
-                <div class="modal-body">
-                    <div class="row g-2">
-                        <div class="col-12">
-                            <input type="text" class="form-control" placeholder="Album Name" aria-label="Album Name"
-                                   id="name" name="name" required>
-                        </div>
-                        <div class="col-12">
-                            <input type="text" class="form-control" placeholder="Album Description" aria-label="Album Description"
-                                   id="description" name="description">
-                        </div>
-                        <div class="col-md-6">
-                            <div class="input-group w-100">
-                                <input type="password" class="form-control" placeholder="Password" aria-label="Password" id="password" name="password" autocomplete="new-password">
-                                <button type="button" title="Unmask password" id="password-unmask" class="btn btn-secondary btn-sm"><i class="fa-solid fa-eye"></i></button>
-                                <button type="button" title="Copy Password" id="password-copy" class="btn btn-warning btn-sm"><i class="fa-regular fa-copy"></i></button>
-                                <button type="button" title="Generate password" id="password-generate" class="btn btn-info btn-sm"><i class="fa-solid fa-key"></i></button>
-                            </div>
-                        </div>
-                        <div class="col-md-3">
-                            <input type="text" class="form-control" placeholder="Max Views" aria-label="Max Views"
-                                   id="max-views" name="max-views">
-                        </div>
-                        <div class="col-md-3">
-                            <input type="text" class="form-control" placeholder="Expire" aria-label="Expire"
-                                   id="expire" name="expire">
-                        </div>
-                        <div class="col-12">
-                            <div class="form-check form-switch ms-1">
-                                <input class="form-check-input" type="checkbox" role="switch" id="private" name="private">
-                                <label class="form-check-label" for="private">Private</label>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                <div class="modal-footer">
-                    <button class="btn btn-success" type="submit"><i class="fa-solid fa-images me-2"></i> Create</button>
-                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
-                </div>
-            </form>
-        </div>
-    </div>
-</div>
+{% include 'include/album-create-modal.html' %}
 {% endblock %}
 
 {% block tail %}

--- a/app/templates/files/bulk-menu.html
+++ b/app/templates/files/bulk-menu.html
@@ -1,7 +1,6 @@
 {% if full_context %}
-<p class="mb-2">Total Files Displayed: <strong id="total-files-count">{{ files|length }}</strong></p>
-<div class="dropdown">
-    <button id="bulk-actions" class="btn btn-secondary dropdown-toggle" type="button" data-bs-toggle="dropdown" aria-expanded="false" disabled>
+<div id="dt-bulk-wrapper" class="dropdown d-none">
+    <button id="bulk-actions" class="btn btn-secondary btn-sm dropdown-toggle" type="button" data-bs-toggle="dropdown" aria-expanded="false" disabled>
       Bulk Actions
     </button>
     <ul class="dropdown-menu">

--- a/app/templates/files/table.html
+++ b/app/templates/files/table.html
@@ -30,14 +30,10 @@
     <i class="fa-solid fa-lock-open fa-fw me-2 privateIcon"></i>
     <img src="{% static 'images/assets/loading.gif' %}" class="img-responsive gallery-image" alt="Loading Files...">
     <div class="dj-file-link">
-        <span class="d-none d-sm-inline">
+        <span class="d-none d-sm-inline me-1">
             <a class="link-body-emphasis clip dj-file-link-clip" role="button">
                 <i class="fa-regular fa-clipboard"></i></a>
         </span>
-        <span class="d-inline-block d-xxl-inline">
-            <span class="d-inline-block d-lg-inline">
-                <a class="link-body-emphasis dj-file-link-ref" aria-label="file-name"></a>
-            </span>
-        </span>
+        <a class="link-body-emphasis dj-file-link-ref" aria-label="file-name"></a>
     </div>
 </div>

--- a/app/templates/gallery.html
+++ b/app/templates/gallery.html
@@ -28,8 +28,8 @@
 
 {% block body %}
 
-    <div class="container-fluid py-3 px-4">
-        <h1><i class="fa-regular fa-folder-open me-2"></i> {% if album %}{{ album.name }}{% else %}Files{% endif %}</h1>
+    <div class="container-fluid pb-3 pt-2 px-4">
+        {% if album %}<h3 class="mt-1"><i class="fa-regular fa-folder-open me-2"></i> {{ album.name }}</h3>{% endif %}
         <nav class="mb-2" aria-label="Files view">
             <a class="link-body-emphasis show-list" role="button" title="List" href="{% url 'home:files' %}">List</a> |
             <a class="link-body-emphasis show-gallery" role="button" title="Gallery" href={% url 'home:gallery' %}>Gallery</a> |
@@ -37,22 +37,21 @@
                 Slideshow</a>
         </nav>
         {% if request.user.is_superuser and not album %}
-                <div class="float-end">
-                    <select id="user" name="user" class="form-select" aria-label="Default select example">
-                        <option value="" {% if not request.GET.user %}selected{% endif %}>Select a User</option>
-                        <option value="0" {% if request.GET.user == "0" %}selected{% endif %}>All Users</option>
-                        {% for user in users %}
-                            <option value="{{ user.id }}" {% if user.id|stringformat:"i" == request.GET.user %}selected{% endif %}>{{ user.username }}</option>
-                        {% endfor %}
-                    </select>
-                </div>
-        {% endif %}
-        {% if album %}
-        <div class=row>
-            <p class="col-md-10 mb-0">{% if album.info %}{{ album.info }}{% endif %}</p>
-            <p class="col-md-2 text-end">Views: <strong id="views-count">{{ album.view }}</strong></p>
+        <div id="dt-user-select-wrapper" class="d-none">
+            <select id="user" name="user" class="form-select form-select-sm" aria-label="Select user">
+                <option value="" {% if not request.GET.user %}selected{% endif %}>Select a User</option>
+                <option value="0" {% if request.GET.user == "0" %}selected{% endif %}>All Users</option>
+                {% for user in users %}
+                    <option value="{{ user.id }}" {% if user.id|stringformat:"i" == request.GET.user %}selected{% endif %}>{{ user.username }}</option>
+                {% endfor %}
+            </select>
         </div>
         {% endif %}
+        {% if album and album.info %}<p class="mb-1">{{ album.info }}</p>{% endif %}
+        <div class="d-flex justify-content-between align-items-center mb-2">
+            {% if full_context %}<p class="mb-0">Total Files Displayed: <strong id="total-files-count">{{ files|length }}</strong></p>{% endif %}
+            {% if album %}<p class="mb-0 ms-auto">Views: <strong id="views-count">{{ album.view }}</strong></p>{% endif %}
+        </div>
         {% include 'files/bulk-menu.html' %}
         <div id="gallery-container" class="d-flex justify-content-center align-items-center flex-wrap" {% if 'gallery' in request.path %}{% else %} hidden{% endif%}></div>
         {% include 'files/table.html'%}

--- a/app/templates/home.html
+++ b/app/templates/home.html
@@ -11,7 +11,7 @@
 {% endblock %}
 
 {% block body %}
-<div class="container-fluid py-3 px-4">
+<div class="container-fluid pb-3 pt-2 px-4">
 
     <h1 class="">
         <i class="fa-solid fa-house-laptop me-2"></i> {{ site_settings.site_title }}

--- a/app/templates/home.html
+++ b/app/templates/home.html
@@ -8,6 +8,7 @@
 
 {% block head %}
     <link href="{% static 'dist/uppy/uppy.min.css' %}" rel="stylesheet">
+    <link rel="stylesheet" href="{% static 'css/gallery.css' %}" />
 {% endblock %}
 
 {% block body %}

--- a/app/templates/include/album-create-modal.html
+++ b/app/templates/include/album-create-modal.html
@@ -1,0 +1,50 @@
+<div class="modal fade" id="create-album-modal" tabindex="-1" aria-labelledby="create-album-label" aria-hidden="true">
+    <div class="modal-dialog modal-dialog-centered modal-lg">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="create-album-label"><i class="fa-solid fa-images me-2"></i> New Album</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <form id="albumsForm" method="post" action="{% url 'api:album' %}">
+                <div class="modal-body">
+                    <div class="row g-2">
+                        <div class="col-12">
+                            <input type="text" class="form-control" placeholder="Album Name" aria-label="Album Name"
+                                   id="name" name="name" required>
+                        </div>
+                        <div class="col-12">
+                            <input type="text" class="form-control" placeholder="Album Description" aria-label="Album Description"
+                                   id="description" name="description">
+                        </div>
+                        <div class="col-md-6">
+                            <div class="input-group w-100">
+                                <input type="password" class="form-control" placeholder="Password" aria-label="Password" id="password" name="password" autocomplete="new-password">
+                                <button type="button" title="Unmask password" id="password-unmask" class="btn btn-secondary btn-sm"><i class="fa-solid fa-eye"></i></button>
+                                <button type="button" title="Copy Password" id="password-copy" class="btn btn-warning btn-sm"><i class="fa-regular fa-copy"></i></button>
+                                <button type="button" title="Generate password" id="password-generate" class="btn btn-info btn-sm"><i class="fa-solid fa-key"></i></button>
+                            </div>
+                        </div>
+                        <div class="col-md-3">
+                            <input type="text" class="form-control" placeholder="Max Views" aria-label="Max Views"
+                                   id="max-views" name="max-views">
+                        </div>
+                        <div class="col-md-3">
+                            <input type="text" class="form-control" placeholder="Expire" aria-label="Expire"
+                                   id="expire" name="expire">
+                        </div>
+                        <div class="col-12">
+                            <div class="form-check form-switch ms-1">
+                                <input class="form-check-input" type="checkbox" role="switch" id="private" name="private">
+                                <label class="form-check-label" for="private">Private</label>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <div class="modal-footer">
+                    <button class="btn btn-success" type="submit"><i class="fa-solid fa-images me-2"></i> Create</button>
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>

--- a/app/templates/include/album-create-modal.html
+++ b/app/templates/include/album-create-modal.html
@@ -34,7 +34,7 @@
                         </div>
                         <div class="col-12">
                             <div class="form-check form-switch ms-1">
-                                <input class="form-check-input" type="checkbox" role="switch" id="private" name="private">
+                                <input class="form-check-input" type="checkbox" role="switch" aria-checked="false" id="private" name="private">
                                 <label class="form-check-label" for="private">Private</label>
                             </div>
                         </div>

--- a/app/templates/paste.html
+++ b/app/templates/paste.html
@@ -9,7 +9,7 @@
 {% endblock %}
 
 {% block body %}
-<div class="container-fluid py-3 px-4">
+<div class="container-fluid pb-3 pt-2 px-4">
 
     {% include 'include/upload-menu.html' with heading='Paste Text' fa_class='fa-regular fa-file-lines' %}
 

--- a/app/templates/settings/main.html
+++ b/app/templates/settings/main.html
@@ -1,7 +1,7 @@
 {% extends "main.html" %}
 
 {% block body %}
-    <div class="container-fluid py-3 px-4">
+    <div class="container-fluid pb-3 pt-2 px-4">
         <div class="row">
             <div class="col-12 col-md-6">
                 <h1><i class="{% block fa_class %}{% endblock %} me-2"></i> {% block title %}{% endblock %}</h1>

--- a/app/templates/settings/welcome.html
+++ b/app/templates/settings/welcome.html
@@ -9,7 +9,7 @@
 {% block welcome %}{% endblock %}
 
 {% block body %}
-    <div class="container-fluid py-3 px-4">
+    <div class="container-fluid pb-3 pt-2 px-4">
 
         <h1>Welcome To Django Files</h1>
 

--- a/app/templates/shorts.html
+++ b/app/templates/shorts.html
@@ -11,7 +11,7 @@
 {% endblock %}
 
 {% block body %}
-<div class="container-fluid py-3 px-4">
+<div class="container-fluid pb-3 pt-2 px-4">
 
     <h1><i class="fa-solid fa-link me-2"></i> Shorts</h1>
 

--- a/app/templates/stats.html
+++ b/app/templates/stats.html
@@ -11,7 +11,7 @@
 {% endblock %}
 
 {% block body %}
-<div class="container-fluid py-3 px-4">
+<div class="container-fluid pb-3 pt-2 px-4">
 
     <h1><i class="fa-solid fa-chart-line me-2"></i> Stats</h1>
 

--- a/app/templates/streams.html
+++ b/app/templates/streams.html
@@ -13,7 +13,7 @@
 
 {% block body %}
 
-    <div class="container-fluid py-3 px-4">
+    <div class="container-fluid pb-3 pt-2 px-4">
         <h1><i class="fa-solid fa-video me-2"></i> Streams</h1>
         {% if request.user.is_superuser %}
                 <div id="user-select-container">

--- a/app/templates/uppy.html
+++ b/app/templates/uppy.html
@@ -9,7 +9,7 @@
 {% endblock %}
 
 {% block body %}
-    <div class="container-fluid py-3 px-4 h-100">
+    <div class="container-fluid pb-3 pt-2 px-4 h-100">
         {% include 'include/upload-menu.html' with heading='Upload Files' fa_class='fa-solid fa-upload' %}
         {% include 'files/uppy-form.html' %}
     </div>


### PR DESCRIPTION
## Changes

**Files list page**
- Removed redundant "Files" page title
- Moved bulk actions button into the DataTables toolbar, left-aligned
- Moved superuser filter dropdown into the DataTables toolbar, right-aligned next to search
- Fixed user select dropdown wrapping to its own row on mobile viewports
- Fixed DataTables processing indicator causing a layout jitter on load (was `position: relative`, overriding DataTables' own `position: absolute`)
- Fixed header row checkbox vertical alignment

**Albums page**
- Removed redundant "Albums" page title
- Replaced inline create album form with a modal, triggered by a "New Album" button injected into the DataTables toolbar
- Modal closes and form resets on successful album creation

**Album view (files list for an album)**
- Reduced album title from `h1` to `h3` with slightly less top spacing
- Moved views counter to the same row as the total files count

**Global**
- Halved top padding between the navbar and page content across all pages (`main.css` body offset reduced, page container top padding reduced from `py-3` to `pb-3 pt-2`)