### PR TITLE
Fix C2: drop token-in-query-string auth, require Bearer scheme

### DIFF
--- a/app/api/test_views.py
+++ b/app/api/test_views.py
@@ -33,7 +33,9 @@ class UserApiTestCase(TestCase):
 
     def test_current_user_get_with_auth(self):
         """Test GET /api/user/ with valid authorization"""
-        response = self.client.get(reverse("api:current-user"), HTTP_AUTHORIZATION=self.regular_user.authorization)
+        response = self.client.get(
+            reverse("api:current-user"), HTTP_AUTHORIZATION=f"Bearer {self.regular_user.authorization}"
+        )
         self.assertEqual(response.status_code, 200)
 
     def test_current_user_get_without_auth(self):
@@ -43,12 +45,14 @@ class UserApiTestCase(TestCase):
 
     def test_users_list_as_superuser(self):
         """Test GET /api/users/ as superuser"""
-        response = self.client.get(reverse("api:users"), HTTP_AUTHORIZATION=self.superuser.authorization)
+        response = self.client.get(reverse("api:users"), HTTP_AUTHORIZATION=f"Bearer {self.superuser.authorization}")
         self.assertEqual(response.status_code, 200)
 
     def test_users_list_as_regular_user_denied(self):
         """Test GET /api/users/ as regular user (should be denied)"""
-        response = self.client.get(reverse("api:users"), HTTP_AUTHORIZATION=self.regular_user.authorization)
+        response = self.client.get(
+            reverse("api:users"), HTTP_AUTHORIZATION=f"Bearer {self.regular_user.authorization}"
+        )
         self.assertEqual(response.status_code, 403)
 
 
@@ -84,7 +88,7 @@ class OrderingApiTestCase(TestCase):
         Stream.objects.create(name="mike", title="m", user=self.user, unique_views=3)
 
     def _get(self, url):
-        return self.client.get(url, HTTP_AUTHORIZATION=self.auth)
+        return self.client.get(url, HTTP_AUTHORIZATION=f"Bearer {self.auth}")
 
     # ----- albums -----
 
@@ -147,7 +151,7 @@ class StreamLifecycleTestCase(TestCase):
         self.auth = self.user.authorization
 
     def _get(self, url):
-        return self.client.get(url, HTTP_AUTHORIZATION=self.auth)
+        return self.client.get(url, HTTP_AUTHORIZATION=f"Bearer {self.auth}")
 
     def test_stream_list_empty(self):
         r = self._get(reverse("api:streams"))

--- a/app/api/views.py
+++ b/app/api/views.py
@@ -136,12 +136,13 @@ def auth_from_token(view=None, no_fail=False):
     def wrapper(request, *args, **kwargs):
         if getattr(request, "user", None) and request.user.is_authenticated:
             return view(request, *args, **kwargs)
-        authorization = (
-            request.headers.get("Authorization") or request.headers.get("Token") or request.GET.get("token")
-        )
-        # log.debug('authorization: %s', authorization)
-        if authorization:
-            user = CustomUser.objects.filter(authorization=authorization)
+        auth_header = request.headers.get("Authorization", "")
+        if auth_header.startswith("Bearer "):
+            token = auth_header[7:]
+        else:
+            token = request.headers.get("Token", "")
+        if token:
+            user = CustomUser.objects.filter(authorization=token)
             if user:
                 request.user = user[0]
                 return view(request, *args, **kwargs)


### PR DESCRIPTION
## Summary

- Removes `request.GET.get("token")` from `auth_from_token` — tokens can no longer appear in HTTP query strings, eliminating leakage into nginx access logs, `Referer` headers, browser history, and screenshots
- Closes the login-CSRF / session-grafting vector on `auth_session`: a cross-origin auto-submitting form with `?token=…` in the URL can no longer mint a session cookie
- `Authorization` header now requires the `Bearer ` scheme prefix, preventing accidental header reflection; the custom `Token:` header path is unchanged for native clients
- All tests updated to send `Authorization: Bearer <token>`

## Security issue addressed

**C2 — Token-in-query-string + session-minting endpoint = persistent takeover oracle**

`auth_from_token` previously accepted the token via `?token=` GET parameter, which was wired to ~25 endpoints including `auth_session` (`/api/auth/session/`). Because `auth_session` is `@csrf_exempt`, a cross-origin auto-submitting form could exchange a leaked URL token for a long-lived session cookie without the user's interaction.

## Test plan

- [x] `python manage.py test api --verbosity 2 --keepdb` — all 20 tests pass
- [x] `ruff check` / `black --check` / `isort --check` — clean
- [x] RTMP stream auth (`_resolve_stream_user`) verified unaffected — it parses tokens from the RTMP `tcurl` URL server-side and does not use `auth_from_token`