### PR TITLE
Fix skeleton rows causing table shift on narrow viewports

### DIFF
--- a/app/static/js/main.js
+++ b/app/static/js/main.js
@@ -386,6 +386,29 @@ function buildSkeletonRows(tbody, count, specs, varWidths = {}) {
         fragment.appendChild(tr)
     }
     tbody.appendChild(fragment)
+
+    // Mirror DataTables responsive column hiding onto skeleton tds.
+    // DataTables hides columns with inline style="display:none" on <th> elements;
+    // skeleton rows are never processed by DT, so without this their tds for
+    // hidden columns remain visible and inflate the table width on narrow viewports,
+    // pushing the ctx-btn column out of view.
+    const theadThs = tbody
+        .closest('table')
+        ?.querySelectorAll(':scope > thead > tr > th')
+    if (theadThs) {
+        const hiddenIdxs = []
+        theadThs.forEach((th, i) => {
+            if (th.style.display === 'none') hiddenIdxs.push(i)
+        })
+        if (hiddenIdxs.length) {
+            tbody.querySelectorAll('.dt-skeleton-row').forEach((tr) => {
+                hiddenIdxs.forEach((colIdx) => {
+                    const td = tr.children[colIdx]
+                    if (td) td.style.display = 'none'
+                })
+            })
+        }
+    }
 }
 
 /**
@@ -541,7 +564,7 @@ function createPaginatedLoader(dt, opts) {
 function attachInfiniteScroll(dt, loader) {
     const handle = debounce(async (event) => {
         await pageScroll(event, loader.nextPage, loader.load)
-        dt?.columns.adjust().draw()
+        dt?.columns.adjust().draw(false)
     })
     document.addEventListener('scroll', handle)
     window.addEventListener('resize', handle)


### PR DESCRIPTION
## Summary

- Skeleton rows are hand-built and never processed by DataTables, so their `<td>` elements for responsive-hidden columns stayed visible on narrow viewports (mobile Safari, macOS Safari with a smaller window). This made skeleton rows wider than real rows, pushing the ctx-btn column out of view and leaving a gap on the right edge.
- `buildSkeletonRows` now reads the inline `display:none` DataTables responsive sets on `<th>` elements and mirrors it onto the corresponding skeleton `<td>` elements.
- Changed `attachInfiniteScroll` from `.draw()` to `.draw(false)` to stop every scroll/resize from resetting the page scroll position.

## Test plan

- [ ] Scroll the files/gallery table to the bottom with a narrow viewport (mobile Safari or a resized desktop window) — confirm no rightward gap appears when skeleton rows load
- [ ] Confirm the same on the albums table
- [ ] Confirm columns hidden by DataTables responsive are also hidden in skeleton rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)