### PR TITLE
Fix preview sidebar contrast and corner-button overlap

### DIFF
--- a/app/static/css/file-preview-panel.css
+++ b/app/static/css/file-preview-panel.css
@@ -156,7 +156,7 @@
  * preview.css. Both containment layers wrapping .sidebar here need
  * relaxing; this rule must stay below .file-preview-panel .card above
  * since they tie on specificity and this one needs to win. */
-@media (max-width: 410px) {
+@media (width <= 410px) {
     .file-preview-panel-content,
     .file-preview-panel .card {
         contain: style;

--- a/app/static/css/file-preview-panel.css
+++ b/app/static/css/file-preview-panel.css
@@ -139,9 +139,8 @@
     flex: 1;
     overflow: hidden;
     position: relative;
-    /* Establish a stacking context so preview-panel children (sidebar, buttons)
-       are contained and don't bleed onto the gallery page. */
-    isolation: isolate;
+    /* .file-preview-panel (fixed, z-index 1040) already isolates this from
+       the gallery page; no isolation needed here too. */
     contain: layout style;
 }
 
@@ -151,4 +150,15 @@
     height: 100%;
     overflow: hidden;
     contain: layout style paint;
+}
+
+/* Below ~410px the open sidebar covers the panel close button — see
+ * preview.css. Both containment layers wrapping .sidebar here need
+ * relaxing; this rule must stay below .file-preview-panel .card above
+ * since they tie on specificity and this one needs to win. */
+@media (max-width: 410px) {
+    .file-preview-panel-content,
+    .file-preview-panel .card {
+        contain: style;
+    }
 }

--- a/app/static/css/main.css
+++ b/app/static/css/main.css
@@ -832,7 +832,7 @@ body.navbar-snapping header {
     backdrop-filter: blur(6px);
     -webkit-backdrop-filter: blur(6px);
     border: 1px solid rgba(13, 110, 253, 0.35);
-    color: #fff;
+    color: var(--bs-body-color);
 }
 
 .addto-album-group .album-search-input {
@@ -846,7 +846,7 @@ body.navbar-snapping header {
 }
 
 .addto-album-group .album-search-input::placeholder {
-    color: rgba(255, 255, 255, 0.65);
+    color: var(--bs-secondary-color);
 }
 
 .badge.file-album-active {
@@ -859,7 +859,7 @@ body.navbar-snapping header {
     backdrop-filter: blur(6px);
     -webkit-backdrop-filter: blur(6px);
     border: 1px solid rgba(13, 110, 253, 0.35);
-    color: #fff;
+    color: var(--bs-body-color);
 }
 
 .badge.file-album-active a {
@@ -868,7 +868,7 @@ body.navbar-snapping header {
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
-    color: #fff;
+    color: var(--bs-body-color);
 }
 
 .badge.file-album-active .remove-album {
@@ -891,11 +891,11 @@ body.navbar-snapping header {
     backdrop-filter: blur(6px);
     -webkit-backdrop-filter: blur(6px);
     border: 1px solid rgba(13, 202, 240, 0.35);
-    color: #fff; /* NOSONAR: badge only appears on dark glass sidebar; contrast is fine in context */
+    color: var(--bs-body-color);
 }
 
 .badge.file-tag-active .remove-tag {
-    color: #fff; /* NOSONAR */
+    color: var(--bs-body-color);
     flex-shrink: 0;
 }
 
@@ -906,7 +906,7 @@ body.navbar-snapping header {
     backdrop-filter: blur(6px);
     -webkit-backdrop-filter: blur(6px);
     border: 1px solid rgba(13, 202, 240, 0.35);
-    color: #fff; /* NOSONAR */
+    color: var(--bs-body-color);
 }
 
 .addto-tag-group .tag-search-input {
@@ -920,5 +920,5 @@ body.navbar-snapping header {
 }
 
 .addto-tag-group .tag-search-input::placeholder {
-    color: rgba(255, 255, 255, 0.65);
+    color: var(--bs-secondary-color);
 }

--- a/app/static/css/preview.css
+++ b/app/static/css/preview.css
@@ -238,7 +238,7 @@ body.no-top-navbar .preview-floating-hamburger {
  * .card (incl. the opaque preview behind it) could out-rank the button —
  * dropping to `contain: style` here lets .sidebar itself escape and cover
  * just that corner, leaving the rest of the preview unaffected. */
-@media (max-width: 410px) {
+@media (width <= 410px) {
     .card {
         contain: style;
     }

--- a/app/static/css/preview.css
+++ b/app/static/css/preview.css
@@ -232,6 +232,22 @@ body.no-top-navbar .preview-floating-hamburger {
     padding-right: 360px;
 }
 
+/* Below ~410px the open sidebar reaches the top-left corner button
+ * (hamburger or panel close, both z-index 1032/10). .card's containment
+ * normally traps .sidebar's z-index as one atomic layer, so only the whole
+ * .card (incl. the opaque preview behind it) could out-rank the button —
+ * dropping to `contain: style` here lets .sidebar itself escape and cover
+ * just that corner, leaving the rest of the preview unaffected. */
+@media (max-width: 410px) {
+    .card {
+        contain: style;
+    }
+
+    .sidebar {
+        z-index: 1033;
+    }
+}
+
 .preview-wrapper {
     position: relative;
     flex: 1;

--- a/app/static/js/album-selector.js
+++ b/app/static/js/album-selector.js
@@ -184,8 +184,7 @@ export function initAlbumSelector(container, socket) {
             const addGroup = container.querySelector('.addto-album-group')
             for (const [key, value] of Object.entries(data.added_to)) {
                 const span = document.createElement('span')
-                span.className =
-                    'badge rounded-pill text-bg-primary ps-2 file-album-active'
+                span.className = 'badge rounded-pill ps-2 file-album-active'
                 span.id = `album-${key}`
                 span.innerHTML = `
                     <a class="text-reset text-decoration-none p-0" href="/files/?view=gallery&album=${key}" title="${value}">${value} </a>
@@ -245,8 +244,7 @@ export function initBulkAlbumSelector(container, socket, pks) {
         }
         const addGroup = albumContainer.querySelector('.addto-album-group')
         const span = document.createElement('span')
-        span.className =
-            'badge rounded-pill text-bg-primary ps-2 file-album-active'
+        span.className = 'badge rounded-pill ps-2 file-album-active'
         span.id = `album-${id}`
         span.innerHTML = `
             <a class="text-reset text-decoration-none p-0" href="/files/?view=gallery&album=${id}" title="${name}">${name} </a>

--- a/app/static/js/file-context-menu.js
+++ b/app/static/js/file-context-menu.js
@@ -192,7 +192,7 @@ fileAlbumModal.on('hidden.bs.modal', () => {
 })
 
 const ADD_GROUP_HTML = `
-    <span class="badge rounded-pill text-bg-primary addto-album-group">
+    <span class="badge rounded-pill addto-album-group">
         <button class="btn p-0 addto-album"><i class="fa-solid fa-plus"></i></button>
         <span class="album-add-container d-none">
             <input class="album-search-input" autocomplete="off" placeholder="Search albums…">
@@ -202,7 +202,7 @@ const ADD_GROUP_HTML = `
 
 function albumBadgeHtml(id, label) {
     return `
-        <span class="badge rounded-pill text-bg-primary ps-2 file-album-active" id="album-${id}">
+        <span class="badge rounded-pill ps-2 file-album-active" id="album-${id}">
             <a class="text-reset text-decoration-none p-0" href="/files/?view=gallery&album=${id}" title="${label}">${label} </a>
             <button id="remove-album-${id}" class="btn p-0 mt-0 remove-album">
                 <i class="fa-solid fa-xmark text-small remove-album"></i>

--- a/app/templates/embed/_preview_album_badge.html
+++ b/app/templates/embed/_preview_album_badge.html
@@ -1,0 +1,6 @@
+<span class="badge rounded-pill ps-2 ms-1 file-album-active pb-0 pt-0 mt-1 mb-1 d-none album-badge" id="">
+    <a class="text-reset text-decoration-none p-0 album-badge-label" href="" aria-label="Album"></a>
+    <button id="remove-album-" class="btn p-0 mt-0 remove-album">
+        <i class="fa-solid fa-xmark text-small remove-album"></i>
+    </button>
+</span>

--- a/app/templates/embed/_preview_chrome.html
+++ b/app/templates/embed/_preview_chrome.html
@@ -1,0 +1,7 @@
+<button class="openbtn" id="openSidebar"><i class="fa-solid fa-square-caret-left"></i></button>
+<div class="context-placement" data-bs-toggle="dropdown" id="contextPlacement" title="More options">
+    <i class="fa-solid fa-ellipsis"></i>
+    <button class="file-context-dropdown my-0 py-0" type="button" aria-expanded="false" hidden></button>
+</div>
+{% include 'files/ctx-menu.html' with file=file extraclass='dropdown-menu-end' %}
+{% include 'embed/_preview_sidebar.html' %}

--- a/app/templates/embed/_preview_media.html
+++ b/app/templates/embed/_preview_media.html
@@ -1,0 +1,32 @@
+{% if render == 'image' %}
+    <div class="preview-wrapper">
+        <div class="img-skeleton" id="img-skeleton"
+             {% if file.thumb %}data-thumb="{% url 'home:url-raw-redirect' file.name %}?thumb=1"{% endif %}></div>
+        <img src="{{ static_url }}" alt="{{ file.name }}" class="preview"
+             style="opacity: 0; transition: opacity {{ media_transition }} ease;">
+    </div>
+{% elif render == 'video' %}
+    <div class="preview-wrapper">
+        <video class="preview" controls>
+            <source src="{{ static_url }}" type="video/mp4">
+            <track kind="captions" src="" default>
+            Your browser does not support the video tag.
+        </video>
+    </div>
+{% elif render == 'audio' %}
+    <div class="position-absolute top-50 start-0 end-0 translate-middle-y px-3">
+        <audio class="w-100" controls>
+            <source src="{{ static_url }}" type="{{ file.mime }}">
+            Your browser does not support the audio tag.
+        </audio>
+    </div>
+{% elif file.mime == 'application/pdf' %}
+    <embed src="{{ static_url }}" type="application/pdf" frameBorder="0" scrolling="auto" width="100%" class="h-100 pt-3 mt-5">
+{% elif render in 'text,code' %}
+    <pre class="pt-3 ps-3 w-100"><code id="text-preview"><i class="fas fa-spinner fa-pulse"></i></code></pre>
+{% elif render == 'markdown' %}
+    <div id="md-rendered" class="markdown-body overflow-auto h-100 px-4 py-3{% if md_extra_class %} {{ md_extra_class }}{% endif %}">{{ markdown|safe }}<!-- //NOSONAR --></div>
+    <pre id="md-source" class="pt-3 ps-3 w-100 d-none"><code id="text-preview"></code></pre>
+{% else %}
+    <div class="d-flex align-items-center justify-content-center h-100 w-100"><i class="fa-10x fa-solid fa-file"></i></div>
+{% endif %}

--- a/app/templates/embed/_preview_sidebar.html
+++ b/app/templates/embed/_preview_sidebar.html
@@ -135,14 +135,14 @@
             <h6 class="pt-3">Albums</h6>
             <div class="album-container position-relative" id="albums-file-{{ file.id }}">
                 {% for album in file.albums.all %}
-                    <span class="badge rounded-pill text-bg-primary ps-2 file-album-active" id="album-{{ album.id }}">
+                    <span class="badge rounded-pill ps-2 file-album-active" id="album-{{ album.id }}">
                         <a class="text-reset text-decoration-none p-0" href="/files/?view=gallery&album={{ album.id }}">{{ album.name }} </a>
                         <button id="remove-album-{{ album.id }}" class="btn p-0 mt-0 remove-album">
                             <i class="fa-solid fa-xmark text-small remove-album"></i>
                         </button>
                     </span>
                 {% endfor %}
-                <span class="badge rounded-pill text-bg-primary addto-album-group">
+                <span class="badge rounded-pill addto-album-group">
                     <button class="btn p-0 addto-album"><i class="fa-solid fa-plus"></i></button>
                     <span class="album-add-container d-none">
                         <input name="add-album-list" class="album-search-input" autocomplete="off" placeholder="Search albums…">

--- a/app/templates/embed/preview.html
+++ b/app/templates/embed/preview.html
@@ -87,60 +87,16 @@ Frame Rate: {{ file.meta.FrameRate }} fps{% endif %}
     <div class="card h-100 border-0 rounded-0"
          data-render="{{ render }}"
          {% if render == 'markdown' %}data-raw-url="{% url 'home:url-raw-redirect' file.file.name %}{% if file.password %}?password={{ file.password }}{% endif %}"{% endif %}>
-        {% if render == 'image' %}
-            <div class="preview-wrapper">
-                <div class="img-skeleton" id="img-skeleton"
-                     {% if file.thumb %}data-thumb="{% url 'home:url-raw-redirect' file.name %}?thumb=1"{% endif %}></div>
-                <img src="{{ static_url }}" alt="{{ file.name }}" class="preview"
-                     style="opacity: 0; transition: opacity 0.4s ease;">
-            </div>
-        {% elif render == 'video' %}
-            <div class="preview-wrapper">
-                <video class="preview" controls>
-                    <source src="{{ static_url }}" type="video/mp4">
-                    <track kind="captions" src="" default>
-                    Your browser does not support the video tag.
-                </video>
-            </div>
-        {% elif render == 'audio' %}
-            <div class="position-absolute top-50 start-0 end-0 translate-middle-y px-3">
-                <audio class="w-100" controls>
-                    <source src="{{ static_url }}" type="{{ file.mime }}">
-                    Your browser does not support the audio tag.
-                </audio>
-            </div>
-        {% elif file.mime == 'application/pdf' %}
-            <embed src="{{ static_url }}" type="application/pdf" frameBorder="0" scrolling="auto" width="100%" class="h-100 pt-3 mt-5">               
-        {% elif render in 'text,code' %}
+        {% if render in 'text,code,markdown' %}
             <link rel="stylesheet" href="{% static 'highlightjs/stackoverflow-dark.min.css' %}" id="code-dark">
             <link rel="stylesheet" href="{% static 'highlightjs/stackoverflow-light.min.css' %}" id="code-light" disabled>
             <script src="{% static 'highlightjs/highlight.min.js' %}"></script>
-            <pre class="pt-3 ps-3 w-100"><code id="text-preview"><i class="fas fa-spinner fa-pulse"></i></code></pre>
-        {% elif render == 'markdown' %}
-            <link rel="stylesheet" href="{% static 'highlightjs/stackoverflow-dark.min.css' %}" id="code-dark">
-            <link rel="stylesheet" href="{% static 'highlightjs/stackoverflow-light.min.css' %}" id="code-light" disabled>
-            <script src="{% static 'highlightjs/highlight.min.js' %}"></script>
-            <div id="md-rendered" class="markdown-body overflow-auto h-100 px-4 py-3">{{ markdown|safe }}<!-- //NOSONAR --></div>
-            <pre id="md-source" class="pt-3 ps-3 w-100 d-none"><code id="text-preview"></code></pre>
-        {% else %}
-            <div class="d-flex align-items-center justify-content-center h-100 w-100"><i class="fa-10x fa-solid fa-file"></i></div>
         {% endif %}
-        <button class="openbtn" id="openSidebar"><i class="fa-solid fa-square-caret-left"></i></button>
-        <div class="context-placement" data-bs-toggle="dropdown" id="contextPlacement" title="More options">
-            <i class="fa-solid fa-ellipsis"></i>
-            <button class="file-context-dropdown my-0 py-0" type="button" aria-expanded="false" hidden></button>
-        </div>
-        {% include 'files/ctx-menu.html' with file=file extraclass='dropdown-menu-end' %}
-        {% include 'embed/_preview_sidebar.html' %}
+        {% include 'embed/_preview_media.html' with media_transition='0.4s' %}
+        {% include 'embed/_preview_chrome.html' %}
     </div>
 
-    <span class="badge rounded-pill ps-2 ms-1 file-album-active pb-0 pt-0 mt-1 mb-1 d-none album-badge" id="">
-        <a class="text-reset text-decoration-none p-0 album-badge-label" href=""></a>
-        <button id="remove-album-" class="btn p-0 mt-0 remove-album">
-            <i class="fa-solid fa-xmark text-small remove-album"></i>
-        </button>
-    </span>
-
+    {% include 'embed/_preview_album_badge.html' %}
 
     {% include 'files/ctx-modals.html' %}
 {% endblock %}

--- a/app/templates/embed/preview.html
+++ b/app/templates/embed/preview.html
@@ -134,7 +134,7 @@ Frame Rate: {{ file.meta.FrameRate }} fps{% endif %}
         {% include 'embed/_preview_sidebar.html' %}
     </div>
 
-    <span class="badge rounded-pill text-bg-primary ps-2 ms-1 file-album-active pb-0 pt-0 mt-1 mb-1 d-none album-badge" id="">
+    <span class="badge rounded-pill ps-2 ms-1 file-album-active pb-0 pt-0 mt-1 mb-1 d-none album-badge" id="">
         <a class="text-reset text-decoration-none p-0 album-badge-label" href=""></a>
         <button id="remove-album-" class="btn p-0 mt-0 remove-album">
             <i class="fa-solid fa-xmark text-small remove-album"></i>

--- a/app/templates/embed/preview_panel.html
+++ b/app/templates/embed/preview_panel.html
@@ -58,7 +58,7 @@
     {% include 'embed/_preview_sidebar.html' %}
 </div>
 
-<span class="badge rounded-pill text-bg-primary ps-2 ms-1 file-album-active pb-0 pt-0 mt-1 mb-1 d-none album-badge" id="">
+<span class="badge rounded-pill ps-2 ms-1 file-album-active pb-0 pt-0 mt-1 mb-1 d-none album-badge" id="">
     <a class="text-reset text-decoration-none p-0 album-badge-label" href="" aria-label="Album"></a>
     <button id="remove-album-" class="btn p-0 mt-0 remove-album">
         <i class="fa-solid fa-xmark text-small remove-album"></i>

--- a/app/templates/embed/preview_panel.html
+++ b/app/templates/embed/preview_panel.html
@@ -16,51 +16,8 @@
      {% if render in 'text,code,markdown' %}data-raw-url="{% url 'home:url-raw-redirect' file.file.name %}{% if file.password %}?password={{ file.password }}{% endif %}"{% endif %}
      {% if gps_lat and gps_lon %}data-gps-lat="{{ gps_lat }}" data-gps-lon="{{ gps_lon }}"{% endif %}>
 
-    {% if render == 'image' %}
-        <div class="preview-wrapper">
-            <div class="img-skeleton" id="img-skeleton"
-                 {% if file.thumb %}data-thumb="{% url 'home:url-raw-redirect' file.name %}?thumb=1"{% endif %}></div>
-            <img src="{{ static_url }}" alt="{{ file.name }}" class="preview"
-                 style="opacity: 0; transition: opacity 0.3s ease;">
-        </div>
-    {% elif render == 'video' %}
-        <div class="preview-wrapper">
-            <video class="preview" controls>
-                <source src="{{ static_url }}" type="video/mp4">
-                <track kind="captions" src="" default>
-                Your browser does not support the video tag.
-            </video>
-        </div>
-    {% elif render == 'audio' %}
-        <div class="position-absolute top-50 start-0 end-0 translate-middle-y px-3">
-            <audio class="w-100" controls>
-                <source src="{{ static_url }}" type="{{ file.mime }}">
-                Your browser does not support the audio tag.
-            </audio>
-        </div>
-    {% elif file.mime == 'application/pdf' %}
-        <embed src="{{ static_url }}" type="application/pdf" frameBorder="0" scrolling="auto" width="100%" class="h-100 pt-3 mt-5">
-    {% elif render in 'text,code' %}
-        <pre class="pt-3 ps-3 w-100"><code id="text-preview"><i class="fas fa-spinner fa-pulse"></i></code></pre>
-    {% elif render == 'markdown' %}
-        <div id="md-rendered" class="markdown-body overflow-auto h-100 px-4 py-3 mt-5">{{ markdown|safe }}<!-- //NOSONAR --></div>
-        <pre id="md-source" class="pt-3 ps-3 w-100 d-none"><code id="text-preview"></code></pre>
-    {% else %}
-        <div class="d-flex align-items-center justify-content-center h-100 w-100"><i class="fa-10x fa-solid fa-file"></i></div>
-    {% endif %}
-
-    <button class="openbtn" id="openSidebar"><i class="fa-solid fa-square-caret-left"></i></button>
-    <div class="context-placement" data-bs-toggle="dropdown" id="contextPlacement" title="More options">
-        <i class="fa-solid fa-ellipsis"></i>
-        <button class="file-context-dropdown my-0 py-0" type="button" aria-expanded="false" hidden></button>
-    </div>
-    {% include 'files/ctx-menu.html' with file=file extraclass='dropdown-menu-end' %}
-    {% include 'embed/_preview_sidebar.html' %}
+    {% include 'embed/_preview_media.html' with media_transition='0.3s' md_extra_class='mt-5' %}
+    {% include 'embed/_preview_chrome.html' %}
 </div>
 
-<span class="badge rounded-pill ps-2 ms-1 file-album-active pb-0 pt-0 mt-1 mb-1 d-none album-badge" id="">
-    <a class="text-reset text-decoration-none p-0 album-badge-label" href="" aria-label="Album"></a>
-    <button id="remove-album-" class="btn p-0 mt-0 remove-album">
-        <i class="fa-solid fa-xmark text-small remove-album"></i>
-    </button>
-</span>
+{% include 'embed/_preview_album_badge.html' %}


### PR DESCRIPTION
## Summary
- Album/tag badges in the file preview sidebar used Bootstrap's `.text-bg-primary` (forces `color: #fff !important`), making text unreadable in light mode. Removed that class from the badge markup (templates + JS-generated badges) since the badges already have their own custom translucent background/border/color styling.
- On narrow viewports, the sidebar could overlap the corner hamburger (full-page embed) or panel close button (gallery panel) without covering it, because `.card` / `.file-preview-panel-content` establish their own stacking context (via `contain: layout`/`paint`), trapping `.sidebar`'s z-index inside. Below ~410px, containment is relaxed to `contain: style` so `.sidebar` can escape and sit above those buttons directly, without lifting the opaque preview content behind it.

## Test plan
- [ ] Open a file's sidebar in light mode and dark mode; confirm tag/album badge text is readable in both.
- [ ] At a viewport narrower than ~410px, open the sidebar in both the full-page embed (`/file/<name>`) and the gallery panel; confirm the sidebar visually covers the hamburger/close button instead of the button poking through.
- [ ] At normal desktop widths, confirm the hamburger/close button still renders above the preview as before (no regression).