### PR TITLE
Add edit modal for per-user storage quota

### DIFF
--- a/app/api/utils.py
+++ b/app/api/utils.py
@@ -59,6 +59,7 @@ def serialize_user(user: CustomUser) -> Dict[str, Any]:
     """
     user_dict = model_to_dict(user, exclude=["password", "authorization"])
     user_dict["avatar_url"] = user.get_avatar_url()
+    user_dict["storage_quota_human_read"] = user.get_storage_quota_human_read()
     providers = []
     for provider in ("discord", "github", "google"):
         if getattr(user, provider, None) is not None:

--- a/app/api/views.py
+++ b/app/api/views.py
@@ -2342,6 +2342,12 @@ def user_view(request, user_id=None):
                 for field in sensitive_fields:
                     data.pop(field, None)
 
+            if "storage_quota" in data:
+                quota_bytes = human_read_to_byte(str(data["storage_quota"]))
+                if not isinstance(quota_bytes, int):
+                    return JsonResponse({"error": "Invalid storage quota value."}, status=400)
+                data["storage_quota"] = quota_bytes
+
             for key, value in data.items():
                 if hasattr(target_user, key):
                     setattr(target_user, key, value)

--- a/app/static/js/settings-site-users.js
+++ b/app/static/js/settings-site-users.js
@@ -6,6 +6,8 @@ import {
 } from './table-defaults.js'
 
 const usersTable = $('#users-table')
+const editUserModalEl = document.getElementById('edit-user-modal')
+const editUserForm = document.getElementById('editUserForm')
 
 let usersDataTable
 let nextPage = 1
@@ -15,7 +17,12 @@ const dataTablesOptions = {
     ...paginatedTableDefaults,
     order: [1, 'asc'],
     layout: noChromeLayout,
-    columns: [{ data: 'id' }, { data: 'username' }, { data: 'storage_usage' }],
+    columns: [
+        { data: 'id' },
+        { data: 'username' },
+        { data: 'storage_usage' },
+        { data: 'id' },
+    ],
     columnDefs: [
         {
             targets: 0,
@@ -31,6 +38,13 @@ const dataTablesOptions = {
             render: renderStorage,
             responsivePriority: 2,
             width: '220px',
+        },
+        {
+            targets: 3,
+            render: renderActions,
+            responsivePriority: 1,
+            orderable: false,
+            width: '28px',
         },
     ],
 }
@@ -93,6 +107,12 @@ function renderStorage(data, type, row) {
             </div>`
 }
 
+function renderActions(data, type, row) {
+    if (type !== 'display') return data
+    return `<a role="button" class="editUserBtn" title="Edit" data-user-id="${row.id}">
+        <i class="fa-solid fa-pen-to-square link-body-emphasis"></i></a>`
+}
+
 async function addUserRows() {
     if (!fetchLock) {
         fetchLock = true
@@ -109,8 +129,52 @@ async function addUserRows() {
 function showUsersSkeletons(count = 5) {
     const tbody = document.querySelector('#users-table tbody')
     if (!tbody) return
-    buildSkeletonRows(tbody, count, [{ w: 0 }, { w: 160 }, { w: 120 }])
+    buildSkeletonRows(tbody, count, [
+        { w: 0 },
+        { w: 160 },
+        { w: 120 },
+        { w: 24 },
+    ])
 }
+
+usersTable.on('click', '.editUserBtn', (event) => {
+    const userId = event.currentTarget.dataset.userId
+    const row = usersDataTable.row(`#user-${userId}`).data()
+    if (!row) return
+    editUserForm.reset()
+    document.getElementById('edit-user-id').value = row.id
+    document.getElementById('edit-user-name').textContent =
+        row.first_name || row.username
+    document.getElementById('edit-user-storage-quota').value =
+        row.storage_quota_human_read || ''
+    bootstrap.Modal.getOrCreateInstance(editUserModalEl).show()
+})
+
+editUserForm?.addEventListener('submit', async (event) => {
+    event.preventDefault()
+    const userId = document.getElementById('edit-user-id').value
+    const storageQuota = document.getElementById(
+        'edit-user-storage-quota'
+    ).value
+    const response = await fetch(`/api/user/${userId}/`, {
+        method: 'PATCH',
+        body: JSON.stringify({ storage_quota: storageQuota }),
+        headers: {
+            'X-CSRFToken': csrftoken,
+            'Content-Type': 'application/json',
+        },
+    })
+    if (response.ok) {
+        const data = await response.json()
+        const row = usersDataTable.row(`#user-${userId}`)
+        row.data({ ...row.data(), ...data }).draw(false)
+        bootstrap.Modal.getOrCreateInstance(editUserModalEl).hide()
+        show_toast('User updated.', 'success')
+    } else {
+        const data = await response.json().catch(() => ({}))
+        show_toast(data.error || 'Failed to update user.', 'danger')
+    }
+})
 
 document.addEventListener('DOMContentLoaded', async () => {
     usersDataTable = usersTable.DataTable(dataTablesOptions)

--- a/app/templates/settings/site.html
+++ b/app/templates/settings/site.html
@@ -433,13 +433,14 @@
                 </div>
                 <div class="dash-card-body p-0">
                     <table class="display responsive nowrap table table-hover w-100 mb-0" id="users-table"
-                           data-skeleton-cols="80,160,120" data-skeleton-rows="5">
+                           data-skeleton-cols="80,160,120,40" data-skeleton-rows="5">
                         <caption class="visually-hidden">User List</caption>
                         <thead>
                             <tr>
                                 <th scope="col">ID</th>
                                 <th scope="col">User</th>
                                 <th scope="col">Storage</th>
+                                <th scope="col" style="width: 28px;"></th>
                             </tr>
                         </thead>
                         <tbody></tbody>
@@ -537,6 +538,48 @@
                 <div class="modal-footer">
                     <button class="btn btn-success" type="submit">
                         <i class="fa-solid fa-user-plus me-2"></i> Create
+                    </button>
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>
+
+<!-- Edit User Modal -->
+<div class="modal fade" id="edit-user-modal" tabindex="-1"
+     aria-labelledby="edit-user-modal-label" aria-hidden="true">
+    <div class="modal-dialog modal-dialog-centered">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h1 class="modal-title fs-5" id="edit-user-modal-label">
+                    <i class="fa-solid fa-user-pen me-2"></i> Edit User
+                </h1>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <form id="editUserForm" autocomplete="off">
+                <div class="modal-body">
+                    <input type="hidden" id="edit-user-id" name="id">
+                    <div class="mb-3">
+                        <label class="form-label fw-medium">User</label>
+                        <div id="edit-user-name" class="form-control-plaintext py-0 fw-medium"></div>
+                    </div>
+                    <div class="mb-1">
+                        <label for="edit-user-storage-quota" class="form-label fw-medium">
+                            Storage Quota
+                            <span data-bs-toggle="tooltip" data-bs-title="Per-user storage quota. 0 is unlimited.">
+                                <i class="fa-solid fa-circle-info ms-1 fs-6"></i>
+                            </span>
+                        </label>
+                        <input type="text" class="form-control" id="edit-user-storage-quota"
+                               name="storage_quota" placeholder="e.g. 10GB"
+                               aria-describedby="edit-user-storage-quota-invalid">
+                        <div id="edit-user-storage-quota-invalid" class="invalid-feedback"></div>
+                    </div>
+                </div>
+                <div class="modal-footer">
+                    <button type="submit" class="btn btn-primary">
+                        Save <i class="fa-solid fa-floppy-disk ms-1"></i>
                     </button>
                     <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
                 </div>


### PR DESCRIPTION
## Summary
- The superuser table on the Site Settings page (`/settings/site/#users`) now has an "Edit" action per row that opens a modal for editing that user's storage quota.
- The quota input accepts human-friendly values (`5GB`, `10TB`, etc.), matching the existing Global/Default Storage Quota inputs, and is converted server-side via `human_read_to_byte` in the `/api/user/<id>/` PATCH endpoint.
- `serialize_user` now includes `storage_quota_human_read` so the modal can pre-fill the input in the same format used elsewhere.

## Test plan
- [x] `ruff check`, `black --check`, `isort --check`, `bandit`, `npm run lint` all pass
- [x] `python manage.py test` — 79 tests pass
- [x] `python manage.py makemigrations --dry-run --check` — no changes needed
- [x] Manually verified against the local dev stack with Playwright: opened the modal, confirmed prefill for zero and non-zero quotas, saved a new quota and confirmed the table row + toast update live, and confirmed invalid input is rejected with a clear error and no console errors