### PR TITLE
New album modal cleanup + responsive files toolbar

### DIFF
--- a/app/static/css/main.css
+++ b/app/static/css/main.css
@@ -440,6 +440,8 @@ body.navbar-snapping header {
 }
 
 .files-toolbar-views {
+    display: inline-flex;
+    align-items: center;
     gap: 0.15rem;
 }
 
@@ -516,6 +518,31 @@ body.navbar-snapping header {
 .files-toolbar-view.view-active {
     background: rgba(var(--bs-primary-rgb), 0.18);
     opacity: 1;
+}
+
+/* Toolbar overflow tiers, collapsed one at a time by observeToolbar() in
+ * main.js as soon as the row wraps — kept separate from the width-based
+ * breakpoint below since the wrap point varies with page/view context. */
+.files-toolbar--hide-count .files-toolbar-count,
+.files-toolbar--hide-select-all-label
+    #gallery-select-all-btn
+    .files-toolbar-view-label,
+.files-toolbar--hide-bulk-label #bulk-actions .files-toolbar-view-label,
+.files-toolbar--hide-sort-label #gallery-sort-btn .files-toolbar-view-label,
+.files-toolbar--hide-size-label #gallery-size-btn .files-toolbar-view-label,
+.files-toolbar--hide-view-labels .files-toolbar-views .files-toolbar-view-label,
+.files-toolbar--collapse-views .files-toolbar-views {
+    display: none;
+}
+
+/* Collapsed single-icon stand-in for .files-toolbar-views, shown only once
+ * the tier above hides the real nav. */
+.files-toolbar-view-toggle {
+    display: none;
+}
+
+.files-toolbar--collapse-views .files-toolbar-view-toggle {
+    display: inline-flex;
 }
 
 /* Hide labels and count on narrow screens — icons only */

--- a/app/static/js/gallery.js
+++ b/app/static/js/gallery.js
@@ -224,6 +224,16 @@ function setToolbarBtnVisible(btn, visible) {
     }
 }
 
+// Mirrors the active tab's own icon rather than a second hardcoded map.
+function syncViewToggleIcon(view) {
+    const icon = document.getElementById('files-view-toggle-icon')
+    const source = { list: showList, gallery: showGallery, map: showMap }[
+        view
+    ]?.querySelector('i')
+    if (!icon || !source) return
+    icon.className = source.className
+}
+
 function applyView(view) {
     const container = mapContainer.parentElement
     if (!container) {
@@ -250,6 +260,7 @@ function applyView(view) {
     else if (view === 'gallery') active = showGallery
     else active = showList
     active?.classList.add('view-active')
+    syncViewToggleIcon(view)
 
     setToolbarBtnVisible(
         document.getElementById('gallery-sort-btn'),
@@ -641,6 +652,37 @@ async function initGallery() {
                 syncFilterPopoverState(clone)
                 const userSel = clone.querySelector('#user')
                 if (userSel && activeUser) userSel.value = activeUser
+            },
+        }
+    )
+    initPopupBtn(
+        'files-view-toggle-btn',
+        'files-view-popup-tpl',
+        (tip, popover) => {
+            tip.querySelectorAll('.files-toolbar-view[data-view]').forEach(
+                (optBtn) => {
+                    optBtn.addEventListener('click', (e) => {
+                        changeView(e)
+                        popover.hide()
+                    })
+                }
+            )
+            tip.querySelector('.show-slideshow')?.addEventListener(
+                'click',
+                () => popover.hide()
+            )
+        },
+        {
+            prepareContent: (clone) => {
+                const currentView = params.get('view') || 'list'
+                clone
+                    .querySelectorAll('.files-toolbar-view[data-view]')
+                    .forEach((optBtn) => {
+                        optBtn.classList.toggle(
+                            'view-active',
+                            optBtn.dataset.view === currentView
+                        )
+                    })
             },
         }
     )

--- a/app/static/js/main.js
+++ b/app/static/js/main.js
@@ -280,15 +280,56 @@ function debounce(fn, timeout = 250) {
     }
 }
 
-function observeToolbarHeight(toolbarId, cssVar) {
+// Toolbar items collapsed one tier at a time, least- to most-aggressive, as
+// soon as the row would otherwise wrap. A width breakpoint can't drive this:
+// the wrap point depends on which buttons are visible (list vs. gallery,
+// album vs. not), so it's measured instead (see observeToolbar below).
+const TOOLBAR_COLLAPSE_TIERS = [
+    'files-toolbar--hide-count',
+    'files-toolbar--hide-select-all-label',
+    'files-toolbar--hide-bulk-label',
+    'files-toolbar--hide-sort-label',
+    'files-toolbar--hide-size-label',
+    'files-toolbar--hide-view-labels', // List/Gallery/Map/Slideshow go icon-only...
+    'files-toolbar--collapse-views', // ...then unify into one icon+popup (files-view-toggle-btn)
+]
+
+/**
+ * One ResizeObserver per toolbar, driving both the --toolbar-h CSS var and
+ * the collapse tiers above — two observers on the same element would double
+ * the layout work per resize for no benefit.
+ */
+function observeToolbar(toolbarId, cssVar) {
     const toolbar = document.getElementById(toolbarId)
     if (!toolbar) return
-    const sync = () =>
+    const firstRowItem = toolbar.querySelector(
+        ':scope > :not(.files-toolbar-album-row)'
+    )
+    const actions = toolbar.querySelector('.files-toolbar-actions')
+    // Sibling buttons on the same row can differ by a px or two from
+    // padding/line-height, so only a full row's worth of offset counts.
+    const isWrapped = () =>
+        !!firstRowItem &&
+        !!actions &&
+        actions.getBoundingClientRect().top -
+            firstRowItem.getBoundingClientRect().top >
+            10
+
+    const sync = () => {
         document.documentElement.style.setProperty(
             cssVar,
             `${toolbar.offsetHeight}px`
         )
+        toolbar.classList.remove(...TOOLBAR_COLLAPSE_TIERS)
+        for (const tier of TOOLBAR_COLLAPSE_TIERS) {
+            if (!isWrapped()) break
+            toolbar.classList.add(tier)
+        }
+    }
     sync()
+    // Also fires when content (not just viewport width) changes how many
+    // buttons need to fit — e.g. switching list -> gallery view adds
+    // Sort/Display/Select-all without any window resize.
     new ResizeObserver(sync).observe(toolbar)
 }
 
@@ -297,7 +338,7 @@ function initToolbar(toolbarId, dt) {
     const searchInputId = `${toolbarId}-search-input`
     if (dt) wireToolbarSearch(searchInputId, dt)
     initCollapsibleSearch(`${toolbarId}-search`, searchInputId)
-    observeToolbarHeight(toolbarId, '--toolbar-h')
+    observeToolbar(toolbarId, '--toolbar-h')
 }
 
 function wireToolbarSearch(inputId, dt) {

--- a/app/templates/albums/create-modal.html
+++ b/app/templates/albums/create-modal.html
@@ -33,13 +33,13 @@
                                    id="expire" name="expire">
                         </div>
                         <div class="col-12">
-                            <div class="form-check form-switch ms-1">
+                            <div class="form-check form-switch" style="margin-left: 0.75rem">
                                 <input class="form-check-input" type="checkbox" role="switch" aria-checked="false" id="private" name="private">
                                 <label class="form-check-label" for="private">Private</label>
                             </div>
                         </div>
                         <div class="col-12">
-                            <span class="form-label fw-semibold d-block">Tags <span class="text-muted fw-normal">(optional)</span></span>
+                            <span class="form-label fw-semibold d-block">Tags</span>
                             {# chips and the "+" adder are rendered by album-create.js via tag-chips.js #}
                             <div class="tag-container position-relative" id="create-album-tags"></div>
                             <input type="hidden" id="album-tags" name="tags">

--- a/app/templates/albums/create-modal.html
+++ b/app/templates/albums/create-modal.html
@@ -16,11 +16,6 @@
                             <input type="text" class="form-control" placeholder="Album Description" aria-label="Album Description"
                                    id="description" name="description">
                         </div>
-                        <div class="col-12">
-                            {# chips and the "+" adder are rendered by album-create.js via tag-chips.js #}
-                            <div class="tag-container position-relative" id="create-album-tags"></div>
-                            <input type="hidden" id="album-tags" name="tags">
-                        </div>
                         <div class="col-md-6">
                             <div class="input-group w-100">
                                 <input type="password" class="form-control" placeholder="Password" aria-label="Password" id="password" name="password" autocomplete="new-password">
@@ -42,6 +37,12 @@
                                 <input class="form-check-input" type="checkbox" role="switch" aria-checked="false" id="private" name="private">
                                 <label class="form-check-label" for="private">Private</label>
                             </div>
+                        </div>
+                        <div class="col-12">
+                            <span class="form-label fw-semibold d-block">Tags <span class="text-muted fw-normal">(optional)</span></span>
+                            {# chips and the "+" adder are rendered by album-create.js via tag-chips.js #}
+                            <div class="tag-container position-relative" id="create-album-tags"></div>
+                            <input type="hidden" id="album-tags" name="tags">
                         </div>
                     </div>
                 </div>

--- a/app/templates/include/files-toolbar.html
+++ b/app/templates/include/files-toolbar.html
@@ -10,7 +10,7 @@
             aria-label="Navigation">
         <i class="fa-solid fa-bars" aria-hidden="true"></i>
     </button>
-    <nav class="files-toolbar-views d-inline-flex align-items-center" aria-label="Files view">
+    <nav class="files-toolbar-views" aria-label="Files view">
         <a class="files-toolbar-view show-list{% if view_mode == 'list' %} view-active{% endif %}" role="button" data-view="list" title="List" href="{% url 'home:files' %}">
             <i class="fa-solid fa-list" aria-hidden="true"></i><span class="files-toolbar-view-label">List</span>
         </a>
@@ -24,6 +24,29 @@
             <i class="fa-solid fa-play" aria-hidden="true"></i><span class="files-toolbar-view-label">Slideshow</span>
         </a>
     </nav>
+
+    {# Collapsed stand-in for .files-toolbar-views on extremely narrow viewports; see observeToolbar() in main.js. #}
+    <button id="files-view-toggle-btn"
+            class="files-toolbar-btn files-toolbar-view-toggle"
+            aria-label="Change view">
+        <i id="files-view-toggle-icon" class="{% if view_mode == 'gallery' %}fa-regular fa-images{% elif view_mode == 'map' %}fa-solid fa-map-location-dot{% else %}fa-solid fa-list{% endif %}" aria-hidden="true"></i>
+    </button>
+    <template id="files-view-popup-tpl">
+        <div class="d-flex flex-column gap-1" style="min-width:160px">
+            <a class="btn btn-sm text-start files-toolbar-view show-list{% if view_mode == 'list' %} view-active{% endif %}" role="button" data-view="list" href="{% url 'home:files' %}">
+                <i class="fa-solid fa-list me-2" aria-hidden="true"></i>List
+            </a>
+            <a class="btn btn-sm text-start files-toolbar-view show-gallery{% if view_mode == 'gallery' %} view-active{% endif %}" role="button" data-view="gallery" href="{% url 'home:files' %}?view=gallery">
+                <i class="fa-regular fa-images me-2" aria-hidden="true"></i>Gallery
+            </a>
+            <a class="btn btn-sm text-start files-toolbar-view show-map{% if view_mode == 'map' %} view-active{% endif %}" role="button" data-view="map" href="{% url 'home:files' %}?view=map">
+                <i class="fa-solid fa-map-location-dot me-2" aria-hidden="true"></i>Map
+            </a>
+            <a class="btn btn-sm text-start files-toolbar-view show-slideshow" role="button" href="#offcanvas-bottom" data-bs-toggle="offcanvas" aria-controls="offcanvas-bottom">
+                <i class="fa-solid fa-play me-2" aria-hidden="true"></i>Slideshow
+            </a>
+        </div>
+    </template>
 
     <button id="files-filter-btn"
             class="files-toolbar-btn{% if active_types %} view-active{% endif %}"


### PR DESCRIPTION
## Summary
- New Album modal: tags moved to the bottom with a matching label, Private switch alignment fixed, redundant "(optional)" dropped.
- Files toolbar (list/gallery/map, album view): replaced the single width breakpoint with tiered collapsing driven by measured overflow, since the wrap point depends on which buttons are visible, not just viewport width. Fixes the album file view wrapping into 3 toolbar rows on mid-size screens.
- Collapse order: count → select-all/bulk labels → sort/display labels → view tabs go icon-only → view tabs unify into one icon + popup on the narrowest viewports.
- One ResizeObserver per toolbar (was two); reacts correctly to view switches (e.g. list → gallery) that change overflow without a window resize.

## Test plan
- [x] `npm run lint` / `npx prettier --check` pass
- [x] Verified via Playwright across list/gallery/map × album/non-album × 400–1200px: no 2-row wraps, correct tier progression, popup opens/selects/closes, no console errors