### PR TITLE
Speed up test suite: fast hasher + CI caching

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -47,6 +47,15 @@ jobs:
 
       - name: "Setup uv"
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        with:
+          enable-cache: true
+          cache-dependency-glob: "app/requirements-dev.txt"
+
+      - name: "Cache Playwright Browsers"
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('app/requirements-dev.txt') }}
 
       - name: "Python Install"
         working-directory: app
@@ -64,6 +73,7 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: 24
+          cache: "npm"
 
       - name: "Node Install"
         run: |

--- a/app/api/test_views.py
+++ b/app/api/test_views.py
@@ -20,23 +20,24 @@ log = logging.getLogger("app")
 class UserApiTestCase(TestCase):
     """Test User API endpoints - Simple version to avoid timeouts"""
 
-    def setUp(self):
+    @classmethod
+    def setUpTestData(cls):
         """Set up test environment"""
         call_command("loaddata", "settings/fixtures/sitesettings.json", verbosity=0)
 
-        self.superuser = CustomUser.objects.create_superuser(
+        cls.superuser = CustomUser.objects.create_superuser(
             username="superuser",
             email="super@test.com",
             password=TEST_PASSWORD,  # nosec  # NOSONAR
         )
-        self.superuser_token = create_api_token(self.superuser, name="Test Token")
+        cls.superuser_token = create_api_token(cls.superuser, name="Test Token")
 
-        self.regular_user = CustomUser.objects.create_user(
+        cls.regular_user = CustomUser.objects.create_user(
             username="regularuser",
             email="regular@test.com",
             password=TEST_PASSWORD,  # nosec  # NOSONAR
         )
-        self.regular_token = create_api_token(self.regular_user, name="Test Token")
+        cls.regular_token = create_api_token(cls.regular_user, name="Test Token")
 
     def test_current_user_get_with_auth(self):
         """Test GET /api/user/ with valid authorization"""
@@ -72,33 +73,34 @@ class UserApiTestCase(TestCase):
 class OrderingApiTestCase(TestCase):
     """Validate the ?ordering= query param on paginated list endpoints."""
 
-    def setUp(self):
+    @classmethod
+    def setUpTestData(cls):
         call_command("loaddata", "settings/fixtures/sitesettings.json", verbosity=0)
-        self.user = CustomUser.objects.create_user(
+        cls.user = CustomUser.objects.create_user(
             username="orderuser",
             email="order@test.com",
             password=TEST_PASSWORD,  # nosec  # NOSONAR
         )
-        self.auth = create_api_token(self.user, name="Test Token")
+        cls.auth = create_api_token(cls.user, name="Test Token")
 
         # Albums: names "bravo", "alpha", "charlie"; backdate to give them
         # distinct created times since `date` is auto_now_add.
-        self.album_alpha = Albums.objects.create(user=self.user, name="alpha")
-        self.album_bravo = Albums.objects.create(user=self.user, name="bravo")
-        self.album_charlie = Albums.objects.create(user=self.user, name="charlie")
+        cls.album_alpha = Albums.objects.create(user=cls.user, name="alpha")
+        cls.album_bravo = Albums.objects.create(user=cls.user, name="bravo")
+        cls.album_charlie = Albums.objects.create(user=cls.user, name="charlie")
         # Force a known creation ordering: charlie newest, bravo middle, alpha oldest.
-        for offset, album in enumerate([self.album_alpha, self.album_bravo, self.album_charlie]):
+        for offset, album in enumerate([cls.album_alpha, cls.album_bravo, cls.album_charlie]):
             Albums.objects.filter(pk=album.pk).update(date=now() - timedelta(days=10 - offset))
 
         # Shorts
-        ShortURLs.objects.create(url="https://example.com/a", short="zzz", user=self.user, views=5)
-        ShortURLs.objects.create(url="https://example.com/b", short="aaa", user=self.user, views=42)
-        ShortURLs.objects.create(url="https://example.com/c", short="mmm", user=self.user, views=1)
+        ShortURLs.objects.create(url="https://example.com/a", short="zzz", user=cls.user, views=5)
+        ShortURLs.objects.create(url="https://example.com/b", short="aaa", user=cls.user, views=42)
+        ShortURLs.objects.create(url="https://example.com/c", short="mmm", user=cls.user, views=1)
 
         # Streams
-        Stream.objects.create(name="zeta", title="z", user=self.user, unique_views=7)
-        Stream.objects.create(name="alpha", title="a", user=self.user, unique_views=99)
-        Stream.objects.create(name="mike", title="m", user=self.user, unique_views=3)
+        Stream.objects.create(name="zeta", title="z", user=cls.user, unique_views=7)
+        Stream.objects.create(name="alpha", title="a", user=cls.user, unique_views=99)
+        Stream.objects.create(name="mike", title="m", user=cls.user, unique_views=3)
 
     def _get(self, url):
         return self.client.get(url, HTTP_AUTHORIZATION=f"Bearer {self.auth}")
@@ -154,14 +156,15 @@ class OrderingApiTestCase(TestCase):
 class StreamLifecycleTestCase(TestCase):
     """View stream list, create a stream, open the stream page."""
 
-    def setUp(self):
+    @classmethod
+    def setUpTestData(cls):
         call_command("loaddata", "settings/fixtures/sitesettings.json", verbosity=0)
-        self.user = CustomUser.objects.create_user(
+        cls.user = CustomUser.objects.create_user(
             username="streamuser",
             email="stream@test.com",
             password=TEST_PASSWORD,  # nosec  # NOSONAR
         )
-        self.auth = create_api_token(self.user, name="Test Token")
+        cls.auth = create_api_token(cls.user, name="Test Token")
 
     def _get(self, url):
         return self.client.get(url, HTTP_AUTHORIZATION=f"Bearer {self.auth}")
@@ -227,17 +230,18 @@ class HlsAuthRequestTestCase(TestCase):
     bundles or one of the rejection paths.
     """
 
-    def setUp(self):
+    @classmethod
+    def setUpTestData(cls):
         call_command("loaddata", "settings/fixtures/sitesettings.json", verbosity=0)
-        self.user = CustomUser.objects.create_user(
+        cls.user = CustomUser.objects.create_user(
             username="hlsuser",
             email="hls@test.com",
             password=TEST_PASSWORD,  # nosec  # NOSONAR
         )
-        self.public_stream = Stream.objects.create(name="pub", title="Pub", user=self.user, public=True)
-        self.private_stream = Stream.objects.create(name="priv", title="Priv", user=self.user, public=False)
-        self.password_stream = Stream.objects.create(
-            name="locked", title="Locked", user=self.user, public=True, password="hunter2"  # nosec  # NOSONAR
+        cls.public_stream = Stream.objects.create(name="pub", title="Pub", user=cls.user, public=True)
+        cls.private_stream = Stream.objects.create(name="priv", title="Priv", user=cls.user, public=False)
+        cls.password_stream = Stream.objects.create(
+            name="locked", title="Locked", user=cls.user, public=True, password="hunter2"  # nosec  # NOSONAR
         )
 
     def _auth(self, **params):
@@ -312,14 +316,15 @@ class HlsAuthRequestTestCase(TestCase):
 class BearerTokenAuthTestCase(TestCase):
     """Tests for the hashed-at-rest Bearer token authentication scheme."""
 
-    def setUp(self):
+    @classmethod
+    def setUpTestData(cls):
         call_command("loaddata", "settings/fixtures/sitesettings.json", verbosity=0)
-        self.user = CustomUser.objects.create_user(
+        cls.user = CustomUser.objects.create_user(
             username="authuser",
             email="auth@test.com",
             password=TEST_PASSWORD,
         )
-        self.token = create_api_token(self.user, name="Test Token")
+        cls.token = create_api_token(cls.user, name="Test Token")
 
     # --- basic Bearer auth ---
 
@@ -375,14 +380,15 @@ class BearerTokenAuthTestCase(TestCase):
 class TokenRotationTestCase(TestCase):
     """Tests for POST /api/token/ token creation endpoint."""
 
-    def setUp(self):
+    @classmethod
+    def setUpTestData(cls):
         call_command("loaddata", "settings/fixtures/sitesettings.json", verbosity=0)
-        self.user = CustomUser.objects.create_user(
+        cls.user = CustomUser.objects.create_user(
             username="rotateuser",
             email="rotate@test.com",
             password=TEST_PASSWORD,  # nosec  # NOSONAR
         )
-        self.token = create_api_token(self.user, name="Test Token")
+        cls.token = create_api_token(cls.user, name="Test Token")
 
     def test_create_via_session_returns_new_plaintext(self):
         self.client.login(username="rotateuser", password=TEST_PASSWORD)  # nosec  # NOSONAR
@@ -433,17 +439,20 @@ class TokenRotationTestCase(TestCase):
 class LocalAuthForNativeClientTestCase(TestCase):
     """Tests for POST /api/auth/token/ — the native-client login endpoint."""
 
-    def setUp(self):
-        from django.core.cache import cache as _cache
-
+    @classmethod
+    def setUpTestData(cls):
         call_command("loaddata", "settings/fixtures/sitesettings.json", verbosity=0)
-        # Clear rate-limit counters so each test starts with a clean slate.
-        _cache.clear()
-        self.user = CustomUser.objects.create_user(
+        cls.user = CustomUser.objects.create_user(
             username="nativeuser",
             email="native@test.com",
             password=TEST_PASSWORD,  # nosec  # NOSONAR
         )
+
+    def setUp(self):
+        from django.core.cache import cache as _cache
+
+        # Clear rate-limit counters so each test starts with a clean slate.
+        _cache.clear()
 
     def test_login_with_valid_credentials_returns_token(self):
         r = self.client.post(
@@ -513,14 +522,15 @@ class LocalAuthForNativeClientTestCase(TestCase):
 class AuthSessionTestCase(TestCase):
     """Tests for POST /api/auth/session/ — Bearer token → session cookie exchange."""
 
-    def setUp(self):
+    @classmethod
+    def setUpTestData(cls):
         call_command("loaddata", "settings/fixtures/sitesettings.json", verbosity=0)
-        self.user = CustomUser.objects.create_user(
+        cls.user = CustomUser.objects.create_user(
             username="sessionuser",
             email="session@test.com",
             password=TEST_PASSWORD,  # nosec  # NOSONAR
         )
-        self.token = create_api_token(self.user, name="Test Token")
+        cls.token = create_api_token(cls.user, name="Test Token")
 
     def test_bearer_token_exchanges_for_session_cookie(self):
         r = self.client.post(
@@ -553,14 +563,15 @@ class AuthSessionTestCase(TestCase):
 class LogoutTokenRotationTestCase(TestCase):
     """Logout must NOT touch ApiToken rows — only the session is flushed."""
 
-    def setUp(self):
+    @classmethod
+    def setUpTestData(cls):
         call_command("loaddata", "settings/fixtures/sitesettings.json", verbosity=0)
-        self.user = CustomUser.objects.create_user(
+        cls.user = CustomUser.objects.create_user(
             username="logoutuser",
             email="logout@test.com",
             password=TEST_PASSWORD,  # nosec  # NOSONAR
         )
-        self.token = create_api_token(self.user, name="Test Token")
+        cls.token = create_api_token(cls.user, name="Test Token")
 
     def test_token_remains_active_after_logout(self):
         """Logout must leave ApiToken rows untouched."""
@@ -586,9 +597,12 @@ class LogoutTokenRotationTestCase(TestCase):
 class ApiTokenListCreateTestCase(TestCase):
     """GET /api/token/ and POST /api/token/"""
 
-    def setUp(self):
+    @classmethod
+    def setUpTestData(cls):
         call_command("loaddata", "settings/fixtures/sitesettings.json", verbosity=0)
-        self.user = CustomUser.objects.create_user(username="tokenuser", password=TEST_PASSWORD)  # nosec  # NOSONAR
+        cls.user = CustomUser.objects.create_user(username="tokenuser", password=TEST_PASSWORD)  # nosec  # NOSONAR
+
+    def setUp(self):
         self.client.login(username="tokenuser", password=TEST_PASSWORD)  # nosec  # NOSONAR
 
     def test_list_tokens_empty(self):
@@ -642,11 +656,14 @@ class ApiTokenListCreateTestCase(TestCase):
 class ApiTokenDeleteTestCase(TestCase):
     """DELETE /api/token/<uuid>/"""
 
-    def setUp(self):
+    @classmethod
+    def setUpTestData(cls):
         call_command("loaddata", "settings/fixtures/sitesettings.json", verbosity=0)
-        self.user = CustomUser.objects.create_user(username="deluser", password=TEST_PASSWORD)  # nosec  # NOSONAR
+        cls.user = CustomUser.objects.create_user(username="deluser", password=TEST_PASSWORD)  # nosec  # NOSONAR
+        cls.token = ApiToken.objects.create(user=cls.user, token_hash=hash_token("mytoken"), name="My Token")
+
+    def setUp(self):
         self.client.login(username="deluser", password=TEST_PASSWORD)  # nosec  # NOSONAR
-        self.token = ApiToken.objects.create(user=self.user, token_hash=hash_token("mytoken"), name="My Token")
 
     def test_delete_token(self):
         response = self.client.delete(f"/api/token/{self.token.pk}/")
@@ -671,13 +688,14 @@ class ApiTokenDeleteTestCase(TestCase):
 class ApiTokenAuthTestCase(TestCase):
     """auth_from_token middleware with ApiToken model"""
 
-    def setUp(self):
+    @classmethod
+    def setUpTestData(cls):
         call_command("loaddata", "settings/fixtures/sitesettings.json", verbosity=0)
-        self.user = CustomUser.objects.create_user(username="authuser", password=TEST_PASSWORD)  # nosec  # NOSONAR
-        self.plaintext = "testbearertoken12345678"
-        self.token = ApiToken.objects.create(
-            user=self.user,
-            token_hash=hash_token(self.plaintext),
+        cls.user = CustomUser.objects.create_user(username="authuser", password=TEST_PASSWORD)  # nosec  # NOSONAR
+        cls.plaintext = "testbearertoken12345678"
+        cls.token = ApiToken.objects.create(
+            user=cls.user,
+            token_hash=hash_token(cls.plaintext),
             name="Test",
         )
 
@@ -724,13 +742,16 @@ AUTO_PASSWORD_OPTION = "auto-password"  # nosec  # NOSONAR - option name, not a 
 class UploadOptionsTestCase(TestCase):
     """Upload options via POST fields (upload page form) and headers."""
 
-    def setUp(self):
+    @classmethod
+    def setUpTestData(cls):
         call_command("loaddata", "settings/fixtures/sitesettings.json", verbosity=0)
-        self.user = CustomUser.objects.create_user(
+        cls.user = CustomUser.objects.create_user(
             username="uploader",
             email="uploader@test.com",
             password=TEST_PASSWORD,  # nosec  # NOSONAR
         )
+
+    def setUp(self):
         self.client.force_login(self.user)
 
     def tearDown(self):
@@ -816,13 +837,16 @@ class UploadOptionsTestCase(TestCase):
 class RemoteUploadSecurityTestCase(TestCase):
     """SSRF and scheme guards on /api/remote/"""
 
-    def setUp(self):
+    @classmethod
+    def setUpTestData(cls):
         call_command("loaddata", "settings/fixtures/sitesettings.json", verbosity=0)
-        self.user = CustomUser.objects.create_user(
+        cls.user = CustomUser.objects.create_user(
             username="remoteuser",
             email="remote@test.com",
             password=TEST_PASSWORD,  # nosec  # NOSONAR
         )
+
+    def setUp(self):
         self.client.force_login(self.user)
 
     def remote(self, url):

--- a/app/djangofiles/settings.py
+++ b/app/djangofiles/settings.py
@@ -372,6 +372,11 @@ AUTH_PASSWORD_VALIDATORS = [
     {"NAME": "django.contrib.auth.password_validation.NumericPasswordValidator"},
 ]
 
+if "test" in sys.argv or "test_coverage" in sys.argv:
+    # PBKDF2's iteration count is a deliberate prod-only cost; tests create
+    # hundreds of users and don't exercise hashing strength.
+    PASSWORD_HASHERS = ["django.contrib.auth.hashers.MD5PasswordHasher"]
+
 if config("SENTRY_URL", False):
     sentry_sdk.init(
         dsn=config("SENTRY_URL"),

--- a/app/home/test_tags.py
+++ b/app/home/test_tags.py
@@ -19,9 +19,10 @@ def _xmp_exif(tags: list) -> dict:
 
 
 class TagBaseTestCase(TestCase):
-    def setUp(self):
+    @classmethod
+    def setUpTestData(cls):
         call_command("loaddata", "settings/fixtures/sitesettings.json", verbosity=0)
-        self.user = CustomUser.objects.create_user(
+        cls.user = CustomUser.objects.create_user(
             username="taguser",
             email="tag@test.com",
             password=TEST_PASSWORD,  # nosec  # NOSONAR

--- a/app/home/test_webhooks.py
+++ b/app/home/test_webhooks.py
@@ -54,9 +54,10 @@ def _mock_response(status_code=200):
 
 
 class WebhookBaseTestCase(TestCase):
-    def setUp(self):
+    @classmethod
+    def setUpTestData(cls):
         call_command("loaddata", "settings/fixtures/sitesettings.json", verbosity=0)
-        self.user = CustomUser.objects.create_user(
+        cls.user = CustomUser.objects.create_user(
             username="hookuser",
             email="hook@test.com",
             password=TEST_PASSWORD,  # nosec  # NOSONAR
@@ -488,21 +489,22 @@ class WebhookTaskTests(WebhookBaseTestCase):
 
 
 class WebhookApiTests(WebhookBaseTestCase):
-    def setUp(self):
-        super().setUp()
-        self.token = create_api_token(self.user, name="Test Token")
-        self.other_user = CustomUser.objects.create_user(
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+        cls.token = create_api_token(cls.user, name="Test Token")
+        cls.other_user = CustomUser.objects.create_user(
             username="otheruser",
             email="other@test.com",
             password=TEST_PASSWORD,  # nosec  # NOSONAR
         )
-        self.other_token = create_api_token(self.other_user, name="Test Token")
-        self.superuser = CustomUser.objects.create_superuser(
+        cls.other_token = create_api_token(cls.other_user, name="Test Token")
+        cls.superuser = CustomUser.objects.create_superuser(
             username="superuser",
             email="super@test.com",
             password=TEST_PASSWORD,  # nosec  # NOSONAR
         )
-        self.superuser_token = create_api_token(self.superuser, name="Test Token")
+        cls.superuser_token = create_api_token(cls.superuser, name="Test Token")
 
     def _auth(self, token):
         return {"HTTP_AUTHORIZATION": f"Bearer {token}"}
@@ -771,15 +773,16 @@ class PendingDiscordWebhookTests(WebhookBaseTestCase):
 class WebhookSettingsPagesTests(WebhookBaseTestCase):
     """User settings manages user-scoped hooks; site settings manages site-scoped hooks."""
 
-    def setUp(self):
-        super().setUp()
-        self.superuser = CustomUser.objects.create_superuser(
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+        cls.superuser = CustomUser.objects.create_superuser(
             username="superuser",
             email="super@test.com",
             password=TEST_PASSWORD,  # nosec  # NOSONAR
         )
-        self.site_hook = Webhook.objects.create(
-            owner=self.superuser,
+        cls.site_hook = Webhook.objects.create(
+            owner=cls.superuser,
             name="SiteWideHook",
             url=CUSTOM_URL,
             scope=Webhook.SCOPE_SITE,

--- a/app/oauth/tests.py
+++ b/app/oauth/tests.py
@@ -2,6 +2,7 @@ import json
 import logging
 import types
 
+from django.core.cache import cache
 from django.core.management import call_command
 from django.test import TestCase
 from django.urls import reverse
@@ -10,6 +11,7 @@ from djangofiles.test_utils import TEST_PASSWORD, WEAK_PASSWORD, WRONG_PASSWORD
 from oauth import passkeys
 from oauth.models import CustomUser, Discord, PasskeyCredential, UserInvites
 from oauth.providers.helpers import create_oauth_user, get_or_create_user
+from settings.managers import CACHE_KEY as SITE_SETTINGS_CACHE_KEY
 from settings.models import SiteSettings
 
 log = logging.getLogger("app")
@@ -18,8 +20,15 @@ log = logging.getLogger("app")
 class PasskeyConfigTest(TestCase):
     """RP derivation from SiteSettings.site_url."""
 
-    def setUp(self):
+    @classmethod
+    def setUpTestData(cls):
         call_command("loaddata", "settings/fixtures/sitesettings.json", verbosity=0)
+
+    def setUp(self):
+        # SiteSettings.objects.settings() caches in Redis, which survives the
+        # per-test DB rollback; tests here mutate and save the singleton, so
+        # clear the cache each test to avoid reading a previous test's value.
+        cache.delete(SITE_SETTINGS_CACHE_KEY)
 
     def test_get_rp_from_site_url(self):
         site = SiteSettings.objects.settings()
@@ -42,17 +51,24 @@ class PasskeyConfigTest(TestCase):
 class PasskeyViewTest(TestCase):
     """Passkey registration/authentication endpoints."""
 
-    def setUp(self):
+    @classmethod
+    def setUpTestData(cls):
         call_command("loaddata", "settings/fixtures/sitesettings.json", verbosity=0)
         site = SiteSettings.objects.settings()
         site.site_url = "https://example.com"
         site.passkey_auth = True
         site.save()
-        self.user = CustomUser.objects.create_user(
+        cls.user = CustomUser.objects.create_user(
             username="passkeyuser",
             email="passkey@test.com",
             password=TEST_PASSWORD,  # nosec  # NOSONAR
         )
+
+    def setUp(self):
+        # SiteSettings.objects.settings() caches in Redis, which survives the
+        # per-test DB rollback; tests here mutate and save the singleton, so
+        # clear the cache each test to avoid reading a previous test's value.
+        cache.delete(SITE_SETTINGS_CACHE_KEY)
 
     def _login(self):
         self.client.force_login(self.user)
@@ -139,18 +155,25 @@ class PasskeyViewTest(TestCase):
 class PasskeyInviteTest(TestCase):
     """Passkey account creation via the invite flow."""
 
-    def setUp(self):
+    @classmethod
+    def setUpTestData(cls):
         call_command("loaddata", "settings/fixtures/sitesettings.json", verbosity=0)
         site = SiteSettings.objects.settings()
         site.site_url = "https://example.com"
         site.passkey_auth = True
         site.save()
-        self.owner = CustomUser.objects.create_superuser(
+        cls.owner = CustomUser.objects.create_superuser(
             username="owner",
             email="owner@test.com",
             password=TEST_PASSWORD,  # nosec  # NOSONAR
         )
-        self.invite = UserInvites.objects.create(owner=self.owner, max_uses=1)
+        cls.invite = UserInvites.objects.create(owner=cls.owner, max_uses=1)
+
+    def setUp(self):
+        # SiteSettings.objects.settings() caches in Redis, which survives the
+        # per-test DB rollback; tests here mutate and save the singleton, so
+        # clear the cache each test to avoid reading a previous test's value.
+        cache.delete(SITE_SETTINGS_CACHE_KEY)
 
     def _begin_url(self, code):
         return reverse("oauth:passkey-invite-begin", kwargs={"invite": code})
@@ -196,11 +219,18 @@ class PasskeyInviteTest(TestCase):
 class OAuthUserCreationTest(TestCase):
     """get_or_create_user / create_oauth_user: no username-based account adoption."""
 
-    def setUp(self):
+    @classmethod
+    def setUpTestData(cls):
         call_command("loaddata", "settings/fixtures/sitesettings.json", verbosity=0)
         site = SiteSettings.objects.settings()
         site.oauth_reg = True
         site.save()
+
+    def setUp(self):
+        # SiteSettings.objects.settings() caches in Redis, which survives the
+        # per-test DB rollback; tests here mutate and save the singleton, so
+        # clear the cache each test to avoid reading a previous test's value.
+        cache.delete(SITE_SETTINGS_CACHE_KEY)
 
     @staticmethod
     def _req():
@@ -256,9 +286,10 @@ class OAuthUserCreationTest(TestCase):
 class OAuthUsernameViewTest(TestCase):
     """The post-signup username interstitial."""
 
-    def setUp(self):
+    @classmethod
+    def setUpTestData(cls):
         call_command("loaddata", "settings/fixtures/sitesettings.json", verbosity=0)
-        self.user = CustomUser.objects.create_user(username="auto1234", password=TEST_PASSWORD)  # nosec  # NOSONAR
+        cls.user = CustomUser.objects.create_user(username="auto1234", password=TEST_PASSWORD)  # nosec  # NOSONAR
 
     def test_requires_login(self):
         response = self.client.get(reverse("oauth:username"))
@@ -298,8 +329,15 @@ class OAuthUsernameViewTest(TestCase):
 class FirstRunSetupTest(TestCase):
     """First-run bootstrap: create the initial admin only while none exists."""
 
-    def setUp(self):
+    @classmethod
+    def setUpTestData(cls):
         call_command("loaddata", "settings/fixtures/sitesettings.json", verbosity=0)
+
+    def setUp(self):
+        # SiteSettings.objects.settings() caches in Redis, which survives the
+        # per-test DB rollback; tests here mutate and save the singleton, so
+        # clear the cache each test to avoid reading a previous test's value.
+        cache.delete(SITE_SETTINGS_CACHE_KEY)
 
     def test_login_redirects_to_setup_when_no_admin(self):
         response = self.client.get(reverse("oauth:login"))
@@ -377,13 +415,20 @@ class FirstRunSetupTest(TestCase):
 class PasskeySetupTest(TestCase):
     """First-run passkey registration for the initial admin."""
 
-    def setUp(self):
+    @classmethod
+    def setUpTestData(cls):
         call_command("loaddata", "settings/fixtures/sitesettings.json", verbosity=0)
         # No site_url: first-run setup derives the RP from the request origin.
         site = SiteSettings.objects.settings()
         site.site_url = ""
         site.passkey_auth = True
         site.save()
+
+    def setUp(self):
+        # SiteSettings.objects.settings() caches in Redis, which survives the
+        # per-test DB rollback; tests here mutate and save the singleton, so
+        # clear the cache each test to avoid reading a previous test's value.
+        cache.delete(SITE_SETTINGS_CACHE_KEY)
 
     def test_begin_returns_options(self):
         response = self.client.post(


### PR DESCRIPTION
## Summary
- Use MD5PasswordHasher during tests instead of default PBKDF2 (~600k iterations) — tests don't need hashing strength, just correctness. Cut `api.test_views` runtime from ~17s to ~3s locally.
- Add caching to `test.yaml` for uv deps, npm deps, and Playwright's Chromium download.
- Convert per-test `setUp` to class-level `setUpTestData` in `api/test_views.py`, `home/test_tags.py`, `home/test_webhooks.py`, and `oauth/tests.py` where safe (no client login inside setUp, no state that needs a fresh DB per test) — fixture loads and user/token creation now run once per test class instead of once per test method.
- While converting `oauth/tests.py`, this exposed a real, pre-existing bug: `SiteSettings.objects.settings()` caches the singleton in Redis, which is not part of the DB transaction Django rolls back after each test. Tests that mutate and save `SiteSettings` were leaving a stale cached value for later tests in the same class — previously masked because the old per-test `setUp()` happened to re-save fresh values before every test. Fixed by clearing the cache key in `setUp()` for the affected classes.

## Test plan
- [x] `python manage.py test` full suite passes (only pre-existing, environment-specific failure unrelated to this change: a hardcoded `/home/runner` media path)
- [x] Verified same failure exists on unmodified master
- [x] Ran affected test modules repeatedly with `--shuffle` (randomized test order) to confirm no cross-test state leakage from the `setUpTestData` conversion
- [x] ruff / black / isort clean on all changed files