### PR TITLE
Fix all-in-one image: tusd binary fails on real multi-platform builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,18 @@ RUN uv pip install --system --no-cache -r /requirements.txt
 FROM ghcr.io/django-files/docker-nginx:1.31.2 AS nginx-base
 
 
-FROM tusproject/tusd:v2 AS tusd-base
+# The tusproject/tusd:v2 *image* is Alpine/musl-based; its binary needs
+# ld-musl-x86_64.so.1, which doesn't exist on this image's Debian/glibc final
+# stage, so exec silently fails with "not found" (exit 127) — not a missing
+# file, a missing dynamic loader. tusd's GitHub release tarballs are true
+# static (CGO_ENABLED=0) binaries, portable to any base — use those instead.
+FROM alpine:3 AS tusd-base
+ARG TARGETARCH
+ARG TUSD_VERSION=v2.10.0
+RUN apk add --no-cache curl  &&\
+    curl -fsSL -o /tmp/tusd.tar.gz "https://github.com/tus/tusd/releases/download/${TUSD_VERSION}/tusd_linux_${TARGETARCH}.tar.gz"  &&\
+    tar -xzf /tmp/tusd.tar.gz -C /tmp  &&\
+    mv "/tmp/tusd_linux_${TARGETARCH}/tusd" /usr/local/bin/tusd
 
 
 FROM python:3.14-slim


### PR DESCRIPTION
## Why

Prod (`0.18.2-beta.4` / `:prerelease`, deployed on the all-in-one image) is 502ing every tus upload:

```
2026/07/20 02:19:30 [error] connect() failed (111: Connection refused) while connecting to upstream,
  ..., upstream: "http://127.0.0.1:8080/tus/", host: "d.luac.es"
```

Container logs show why:

```
/tusd-entrypoint.sh: 29: exec: tusd: not found
WARN exited: tusd (exit status 127; not expected)
...
INFO gave up: tusd entered FATAL state, too many start retries too quickly
```

Root cause: `COPY --from=tusproject/tusd:v2 /usr/local/bin/tusd` copies **only the binary** out of that
image — but `tusproject/tusd:v2` is Alpine (musl libc), and this Dockerfile's final stage is
`python:3.14-slim` (Debian, glibc). The binary is dynamically linked against
`ld-musl-x86_64.so.1`, which doesn't exist here, so `exec` fails with "not found" — not a missing
file, a missing dynamic loader. Confirmed directly:

```
$ docker run --rm --platform linux/amd64 tusproject/tusd:v2 sh -c 'file /usr/local/bin/tusd'
... ELF 64-bit ... dynamically linked, interpreter /lib/ld-musl-x86_64.so.1 ...
```

This was invisible in local testing during the original PR because that testing happened on
native arm64 (Apple Silicon), where the mismatch apparently doesn't manifest the same way; the
real CI build is multi-platform (`linux/amd64,linux/arm64` via QEMU) and both `:prerelease` and
the currently-deployed prod image are confirmed (byte-identical digest check) to be built from
the merged tus PR — so this isn't a stale-image problem, it's a real bug in the fix itself.

## Fix

Stop cross-copying from the Alpine tusd image. Download tusd's official GitHub release tarball
instead — those are true static (`CGO_ENABLED=0`) binaries, portable to any base image regardless
of libc:

```dockerfile
FROM alpine:3 AS tusd-base
ARG TARGETARCH
ARG TUSD_VERSION=v2.10.0
RUN apk add --no-cache curl  &&\
    curl -fsSL -o /tmp/tusd.tar.gz "https://github.com/tus/tusd/releases/download/${TUSD_VERSION}/tusd_linux_${TARGETARCH}.tar.gz"  &&\
    tar -xzf /tmp/tusd.tar.gz -C /tmp  &&\
    mv "/tmp/tusd_linux_${TARGETARCH}/tusd" /usr/local/bin/tusd
```

`TARGETARCH` is buildx's automatic per-platform arg, so this correctly fetches `tusd_linux_amd64`
or `tusd_linux_arm64` per platform in the same multi-platform build. The compose-based sidecar
deployments (`docker-compose*.yaml`, using `tusproject/tusd:v2` as its own standalone container)
are unaffected by this bug — the mismatch only exists when cross-copying the binary out into a
different base image, which only the all-in-one image does.

## Verification

Built and booted **both** platforms via `docker buildx build --platform linux/amd64|arm64 --load`
(the same mechanism CI uses, not just a native build):

- `tusd -version` succeeds on both amd64 and arm64
- Full container boot: `tusd entered RUNNING state` (no crash loop) on both
- End-to-end: `POST /tus/` through nginx → tusd → Django hook returns `401 Invalid Authorization`
  (expected — proves the full proxy chain works, not just the binary)
- `hadolint` clean (no new warnings beyond pre-existing unpinned-package warnings already present
  elsewhere in this file)
- Full test suite: 215/215 passing
- ruff/black/isort/bandit clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)