### PR TITLE
Fix .mov inline preview/unfurl playback

### DIFF
--- a/app/home/models.py
+++ b/app/home/models.py
@@ -131,10 +131,13 @@ class Files(models.Model):
             )
         return abs_url + signed
 
-    def get_meta_static_url(self) -> str:
+    def get_meta_static_url(self, abs_url: str = "") -> str:
         """
         Otherwise some clients may cache an old meta url and it will fail to display when using signed urls.
         There may also be future cases where we dont want to issue this url for private/pw protected files.
+
+        og:video/og:image require an absolute URL or unfurlers (Discord, Slack, iMessage, etc.) silently
+        drop the embed, so the non-S3 branch must be prefixed the same way get_gallery_url() is.
         """
         if use_s3():
             if (meta_static_url := cache.get(f"file.urlcache.meta_static.{self.pk}")) is None:
@@ -151,7 +154,7 @@ class Files(models.Model):
                     int(settings.SIGNED_META_URL_TTL_SECONDS * settings.SIGNED_URL_REFRESH_RATIO),
                 )
             return meta_static_url
-        return self.get_url(False)
+        return abs_url + self.get_url(False)
 
     def get_gallery_url(self, abs_url: str = "") -> str:
         """Generates a static url for use on a gallery page."""
@@ -176,6 +179,18 @@ class Files(models.Model):
 
     def _sign_nginx_url(self, uri: str) -> str:
         return sign_nginx_urls(uri)
+
+    def get_playback_mime(self) -> str:
+        """MIME type actually served for inline playback (see nginx/raw-mime.types).
+
+        .mov is relabeled video/mp4 at serve time since video/quicktime isn't in the
+        MIME allowlist most <video> elements or chat-app inline previewers use to
+        decide whether to attempt playback. Keep that in sync here so declared
+        metadata (og:video:type) matches what the raw URL actually returns.
+        """
+        if self.mime == "video/quicktime":
+            return "video/mp4"
+        return self.mime
 
     def _get_password_query_string(self) -> str:
         if self.password:

--- a/app/home/views.py
+++ b/app/home/views.py
@@ -721,7 +721,7 @@ def url_route_view(request, filename):
         "file": file,
         "render": file.mime.split("/", 1)[0],
         "static_url": file.get_url(view=session_view),
-        "static_meta_url": file.get_meta_static_url(),
+        "static_meta_url": file.get_meta_static_url(site_url),
         "file_avatar_url": file.user.get_avatar_url(),
         "full_context": request.user.is_authenticated and (request.user == file.user or request.user.is_superuser),
         "native_app_arg": (

--- a/app/templates/embed/preview.html
+++ b/app/templates/embed/preview.html
@@ -42,7 +42,7 @@ Frame Rate: {{ file.meta.FrameRate }} fps{% endif %}
         {% endif %}
     {% elif render == 'video' %}
         <meta property="og:video" content="{{ static_meta_url|safe }}">
-        <meta property="og:video:type" content="{{ file.mime }}">
+        <meta property="og:video:type" content="{{ file.get_playback_mime }}">
         <meta property="og:type" content="video.other">
         {% if file.thumb %}
             <meta property="og:image" content="{{ site_settings.site_url }}{% url 'home:url-raw-redirect' file.name %}?thumb=1">

--- a/nginx/raw-mime.types
+++ b/nginx/raw-mime.types
@@ -9,7 +9,11 @@ types {
     video/mp2t                                       ts;
     video/mp4                                        mp4;
     video/mpeg                                       mpeg mpg;
-    video/quicktime                                  mov;
+    # Serve .mov as video/mp4: it shares the ISO base media container with mp4 and
+    # is typically H.264/AAC, but video/quicktime isn't in the MIME allowlist most
+    # <video> elements (Chrome/Firefox) or chat-app inline previewers (Discord,
+    # Slack, iMessage) use to decide whether to attempt inline playback.
+    video/mp4                                        mov;
     video/webm                                       webm;
     video/x-flv                                      flv;
     video/x-m4v                                      m4v;


### PR DESCRIPTION
Relative og:video URL + video/quicktime mislabel were blocking inline mov playback in unfurls and raw links.